### PR TITLE
Improved error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ class Service:
     ...
 
     @grpc
-    def stream_error(self, request, context):
+    def grpc_error_from_exception(self, request, context):
         for index, item in enumerate(...):
             if index > MAX_TOKENS:
                 raise NoMoreTokens("Out of tokens!")

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ class Service:
 2. Return a `GrpcError` directly:
 
 ``` python
-from nameko_grpc.errors import GrpcError
+from nameko_grpc.errors import GrpcError, StatusCode
 
 
 class Service:
@@ -239,7 +239,7 @@ class Service:
 3. Register an error handler mapping a given exception type to a function that generates a `GrpcError` instance from the raised exception:
 
 ``` python
-from nameko_grpc.errors import register
+from nameko_grpc.errors import register_handler, GrpcError, StatusCode
 
 
 class NoMoreTokens(Exception):
@@ -254,7 +254,7 @@ def handle_no_more_tokens(exc, code=None, message=None):
     )
 
 
-register(NoMoreTokens, handle_no_more_tokens)
+register_handler(NoMoreTokens, handle_no_more_tokens)
 
 class Service:
 

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -152,7 +152,7 @@ class ClientBase:
             elapsed = time.time() - start
             if elapsed > deadline:
                 error = GrpcError(
-                    status=StatusCode.DEADLINE_EXCEEDED, message="Deadline Exceeded"
+                    code=StatusCode.DEADLINE_EXCEEDED, message="Deadline Exceeded"
                 )
                 response_stream.close(error)
                 send_stream.close()

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -152,7 +152,7 @@ class ClientBase:
             elapsed = time.time() - start
             if elapsed > deadline:
                 error = GrpcError(
-                    status=StatusCode.DEADLINE_EXCEEDED, details="Deadline Exceeded"
+                    status=StatusCode.DEADLINE_EXCEEDED, message="Deadline Exceeded"
                 )
                 response_stream.close(error)
                 send_stream.close()

--- a/nameko_grpc/connection.py
+++ b/nameko_grpc/connection.py
@@ -74,7 +74,7 @@ class ConnectionManager:
                 "ConnectionManager shutting down with error. Traceback:", exc_info=True,
             )
             error = GrpcError.from_exception(
-                sys.exc_info(), status=StatusCode.UNAVAILABLE
+                sys.exc_info(), code=StatusCode.UNAVAILABLE
             )
         finally:
             for send_stream in self.send_streams.values():
@@ -411,7 +411,7 @@ class ClientConnectionManager(ConnectionManager):
             request_stream = self.send_streams[stream_id]
 
             error = GrpcError(
-                status=StatusCode.UNIMPLEMENTED,
+                code=StatusCode.UNIMPLEMENTED,
                 message="Algorithm not supported: {}".format(request_stream.encoding),
             )
             response_stream.close(error)

--- a/nameko_grpc/connection.py
+++ b/nameko_grpc/connection.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import itertools
 import select
+import sys
 from collections import deque
 from contextlib import contextmanager
 from logging import getLogger
 from threading import Event
-import sys
+
 from grpc import StatusCode
 from h2.config import H2Configuration
 from h2.connection import H2Connection

--- a/nameko_grpc/context.py
+++ b/nameko_grpc/context.py
@@ -65,8 +65,8 @@ class GrpcContext:
     def set_code(self, code):
         self.response_stream.trailers.set(("grpc-status", str(code)))
 
-    def set_details(self, details):
-        self.response_stream.trailers.set(("grpc-message", details))
+    def set_message(self, message):
+        self.response_stream.trailers.set(("grpc-message", message))
 
     def invocation_metadata(self):
         return self.request_stream.headers.for_application

--- a/nameko_grpc/context.py
+++ b/nameko_grpc/context.py
@@ -3,6 +3,7 @@ import json
 
 from nameko_grpc.errors import STATUS_CODE_ENUM_TO_INT_MAP
 
+
 METADATA_PREFIX = "x-nameko-"
 
 

--- a/nameko_grpc/context.py
+++ b/nameko_grpc/context.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
+from grpc._common import STATUS_CODE_TO_CYGRPC_STATUS_CODE
 
 METADATA_PREFIX = "x-nameko-"
 
@@ -63,7 +64,9 @@ class GrpcContext:
         self.response_stream = response_stream
 
     def set_code(self, code):
-        self.response_stream.trailers.set(("grpc-status", str(code)))
+        self.response_stream.trailers.set(
+            ("grpc-status", str(STATUS_CODE_TO_CYGRPC_STATUS_CODE[code]))
+        )
 
     def set_message(self, message):
         self.response_stream.trailers.set(("grpc-message", message))

--- a/nameko_grpc/context.py
+++ b/nameko_grpc/context.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-from grpc._common import STATUS_CODE_TO_CYGRPC_STATUS_CODE
+from nameko_grpc.errors import STATUS_CODE_ENUM_TO_INT_MAP
 
 METADATA_PREFIX = "x-nameko-"
 
@@ -65,7 +65,7 @@ class GrpcContext:
 
     def set_code(self, code):
         self.response_stream.trailers.set(
-            ("grpc-status", str(STATUS_CODE_TO_CYGRPC_STATUS_CODE[code]))
+            ("grpc-status", str(STATUS_CODE_ENUM_TO_INT_MAP[code]))
         )
 
     def set_message(self, message):

--- a/nameko_grpc/entrypoint.py
+++ b/nameko_grpc/entrypoint.py
@@ -42,7 +42,7 @@ class GrpcServer(SharedExtension):
             if elapsed > deadline:
                 request_stream.close()
                 error = GrpcError(
-                    status=StatusCode.DEADLINE_EXCEEDED, message="Deadline Exceeded"
+                    code=StatusCode.DEADLINE_EXCEEDED, message="Deadline Exceeded"
                 )
                 response_stream.close(error)
                 break
@@ -53,14 +53,12 @@ class GrpcServer(SharedExtension):
             method_path = request_stream.headers.get(":path")
             entrypoint = self.entrypoints[method_path]
         except KeyError:
-            raise GrpcError(
-                status=StatusCode.UNIMPLEMENTED, message="Method not found!"
-            )
+            raise GrpcError(code=StatusCode.UNIMPLEMENTED, message="Method not found!")
 
         encoding = request_stream.headers.get("grpc-encoding", "identity")
         if encoding not in SUPPORTED_ENCODINGS:
             raise GrpcError(
-                status=StatusCode.UNIMPLEMENTED,
+                code=StatusCode.UNIMPLEMENTED,
                 message="Algorithm not supported: {}".format(encoding),
             )
 

--- a/nameko_grpc/entrypoint.py
+++ b/nameko_grpc/entrypoint.py
@@ -3,7 +3,7 @@ import time
 import types
 from functools import partial
 from logging import getLogger
-
+import sys
 from grpc import StatusCode
 from nameko import config
 from nameko.exceptions import ContainerBeingKilled
@@ -42,7 +42,7 @@ class GrpcServer(SharedExtension):
             if elapsed > deadline:
                 request_stream.close()
                 error = GrpcError(
-                    status=StatusCode.DEADLINE_EXCEEDED, details="Deadline Exceeded"
+                    status=StatusCode.DEADLINE_EXCEEDED, message="Deadline Exceeded"
                 )
                 response_stream.close(error)
                 break
@@ -54,14 +54,14 @@ class GrpcServer(SharedExtension):
             entrypoint = self.entrypoints[method_path]
         except KeyError:
             raise GrpcError(
-                status=StatusCode.UNIMPLEMENTED, details="Method not found!"
+                status=StatusCode.UNIMPLEMENTED, message="Method not found!"
             )
 
         encoding = request_stream.headers.get("grpc-encoding", "identity")
         if encoding not in SUPPORTED_ENCODINGS:
             raise GrpcError(
                 status=StatusCode.UNIMPLEMENTED,
-                details="Algorithm not supported: {}".format(encoding),
+                message="Algorithm not supported: {}".format(encoding),
             )
 
         timeout = request_stream.headers.get("grpc-timeout")
@@ -186,7 +186,7 @@ class Grpc(Entrypoint):
             )
         except ContainerBeingKilled:
             raise GrpcError(
-                status=StatusCode.UNAVAILABLE, details="Server shutting down"
+                status=StatusCode.UNAVAILABLE, message="Server shutting down"
             )
 
     def handle_result(self, response_stream, worker_ctx, result, exc_info):
@@ -199,14 +199,13 @@ class Grpc(Entrypoint):
                 response_stream.populate(result)
             except Exception as exception:
                 message = "Exception iterating responses: {}".format(exception)
+                error = GrpcError.from_exception(sys.exc_info(), message=message)
 
-                error = GrpcError(status=StatusCode.UNKNOWN, details=message)
                 response_stream.close(error)
         else:
-            error = GrpcError(
-                status=StatusCode.UNKNOWN,
-                details="Exception calling application: {}".format(exc_info[1]),
-            )
+            message = "Exception calling application: {}".format(exc_info[1])
+            error = GrpcError.from_exception(exc_info, message=message)
+
             response_stream.close(error)
 
         return result, exc_info

--- a/nameko_grpc/entrypoint.py
+++ b/nameko_grpc/entrypoint.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+import sys
 import time
 import types
 from functools import partial
 from logging import getLogger
-import sys
+
 from grpc import StatusCode
 from nameko import config
 from nameko.exceptions import ContainerBeingKilled

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -12,8 +12,6 @@ STATUS_CODE_ENUM_TO_INT_MAP = {item: item.value[0] for item in StatusCode}
 
 GRPC_DETAILS_METADATA_KEY = "grpc-status-details-bin"
 
-registry = {}
-
 
 class GrpcError(Exception):
     def __init__(self, code, message, status=None):
@@ -97,6 +95,7 @@ def default_error_from_exception(exc_info, code=None, message=None):
     """
     exc_type, exc, tb = exc_info
 
+    # XXX why accept code and mesage here?
     detail = Any()
     detail.Pack(
         DebugInfo(stack_entries=traceback.format_exception(*exc_info), detail=str(exc),)
@@ -109,3 +108,11 @@ def default_error_from_exception(exc_info, code=None, message=None):
     )
 
     return GrpcError(code=code, message=message, status=status)
+
+
+def grpc_error_passthrough(exc_info, code, message):
+    exc_type, exc, tb = exc_info
+    return exc
+
+
+registry = {GrpcError: grpc_error_passthrough}

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -7,6 +7,7 @@ from google.protobuf.any_pb2 import Any
 from google.rpc.error_details_pb2 import DebugInfo
 from google.rpc.status_pb2 import Status
 
+
 STATUS_CODE_INT_TO_ENUM_MAP = {item.value[0]: item for item in StatusCode}
 STATUS_CODE_ENUM_TO_INT_MAP = {item: item.value[0] for item in StatusCode}
 

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -2,19 +2,17 @@
 import traceback
 
 from grpc import StatusCode
-from grpc._common import (
-    CYGRPC_STATUS_CODE_TO_STATUS_CODE,
-    STATUS_CODE_TO_CYGRPC_STATUS_CODE,
-)
 
 from google.protobuf.any_pb2 import Any
 from google.rpc.error_details_pb2 import DebugInfo
 from google.rpc.status_pb2 import Status
 
-
-registry = {}
+STATUS_CODE_INT_TO_ENUM_MAP = {item.value[0]: item for item in StatusCode}
+STATUS_CODE_ENUM_TO_INT_MAP = {item: item.value[0] for item in StatusCode}
 
 GRPC_DETAILS_METADATA_KEY = "grpc-status-details-bin"
+
+registry = {}
 
 
 class GrpcError(Exception):
@@ -28,7 +26,7 @@ class GrpcError(Exception):
         """
         headers = {
             # ("content-length", "0"),
-            "grpc-status": str(STATUS_CODE_TO_CYGRPC_STATUS_CODE[self.code]),
+            "grpc-status": str(STATUS_CODE_ENUM_TO_INT_MAP[self.code]),
             "grpc-message": self.message,
         }
         if self.status:
@@ -44,7 +42,7 @@ class GrpcError(Exception):
         status = headers.get(GRPC_DETAILS_METADATA_KEY)
 
         return GrpcError(
-            code=CYGRPC_STATUS_CODE_TO_STATUS_CODE[code],
+            code=STATUS_CODE_INT_TO_ENUM_MAP[code],
             message=message,
             status=Status.FromString(status) if status else None,
         )
@@ -107,7 +105,7 @@ def default_error_from_exception(exc_info, code=None, message=None):
     message = message or str(exc)
 
     status = Status(
-        code=STATUS_CODE_TO_CYGRPC_STATUS_CODE[code], message=message, details=[detail],
+        code=STATUS_CODE_ENUM_TO_INT_MAP[code], message=message, details=[detail],
     )
 
     return GrpcError(code=code, message=message, status=status)

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -48,14 +48,14 @@ class GrpcError(Exception):
 
     @staticmethod
     def from_exception(exc_info, code=None, message=None):
-        """ Create a new GrpcError instance representing an underlying exception.
-        The `code` and `message` can be passed to this function.
+        """ Utility method to create a new GrpcError instance representing an
+        underlying exception. Useful in try/except clauses.
 
         By default, a `google.rpc.Status` message will be generated capturing the
         debug info of the underyling traceback. See `default_error_from_exception`.
 
         This can be overridden by registering a new callable against a given exception
-        type. See `register`.
+        type. See `register_exception_handler`.
         """
         exc_type, exc, tb = exc_info
 
@@ -72,7 +72,7 @@ class GrpcError(Exception):
         )
 
 
-def register(exc_type, custom_error_from_exception):
+def register_exception_handler(exc_type, custom_error_from_exception):
     """ Register a custom implementation to generate a GrpcError from an underlying
     exception, by exception type.
 
@@ -81,7 +81,7 @@ def register(exc_type, custom_error_from_exception):
     registry[exc_type] = custom_error_from_exception
 
 
-def unregister(exc_type):
+def unregister_expection_handler(exc_type):
     """ Unregister a custom implementation.
     """
     registry.pop(exc_type, None)
@@ -96,7 +96,6 @@ def default_error_from_exception(exc_info, code=None, message=None):
     """
     exc_type, exc, tb = exc_info
 
-    # XXX why accept code and mesage here?
     detail = Any()
     detail.Pack(
         DebugInfo(stack_entries=traceback.format_exception(*exc_info), detail=str(exc),)
@@ -111,9 +110,9 @@ def default_error_from_exception(exc_info, code=None, message=None):
     return GrpcError(code=code, message=message, status=status)
 
 
-def grpc_error_passthrough(exc_info, code, message):
+def grpc_error_passthrough_exception_handler(exc_info, code, message):
     exc_type, exc, tb = exc_info
     return exc
 
 
-registry = {GrpcError: grpc_error_passthrough}
+registry = {GrpcError: grpc_error_passthrough_exception_handler}

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -3,36 +3,110 @@ from grpc._common import (
     CYGRPC_STATUS_CODE_TO_STATUS_CODE,
     STATUS_CODE_TO_CYGRPC_STATUS_CODE,
 )
+from grpc import StatusCode
+from google.protobuf.any_pb2 import Any
+from google.rpc.error_details_pb2 import DebugInfo
+from google.rpc.status_pb2 import Status
+import traceback
+
+registry = {}
+
+GRPC_DETAILS_METADATA_KEY = "grpc-status-details-bin"
 
 
 class GrpcError(Exception):
-    def __init__(self, status, details, debug_error_string=""):
+    def __init__(self, status, message, details=None):
         self.status = status
+        self.message = message
         self.details = details
-        self.debug_error_string = debug_error_string
 
     def as_headers(self):
-        headers = (
+        """ Dehydrate this instance to headers to be sent as trailing metadata.
+        """
+        headers = {
             # ("content-length", "0"),
-            ("grpc-status", str(STATUS_CODE_TO_CYGRPC_STATUS_CODE[self.status])),
-            ("grpc-message", self.details),
-        )
-        return headers
+            "grpc-status": str(STATUS_CODE_TO_CYGRPC_STATUS_CODE[self.status]),
+            "grpc-message": self.message,
+        }
+        if self.details:
+            headers[GRPC_DETAILS_METADATA_KEY] = self.details.SerializeToString()
+        return list(headers.items())
 
     @staticmethod
     def from_headers(headers):
+        """ Rehydrate a new instance from headers received as trailing metadata.
+        """
         status = int(headers.get("grpc-status"))
         message = headers.get("grpc-message")
+        details = headers.get(GRPC_DETAILS_METADATA_KEY)
 
         return GrpcError(
-            status=CYGRPC_STATUS_CODE_TO_STATUS_CODE[status], details=message
+            status=CYGRPC_STATUS_CODE_TO_STATUS_CODE[status],
+            message=message,
+            details=Status.FromString(details) if details else None,
         )
+
+    @staticmethod
+    def from_exception(exc_info, status=None, message=None):
+        """ Create a new GrpcError instance representing an underlying exception.
+        The `status` and `message` can be passed to this function.
+
+        By default, a `google.rpc.Status` message will be generated capturing the
+        debug info of the underyling traceback. See `default_error_from_exception`.
+
+        This can be overridden by registering a new callable against a given exception
+        type. See `register`.
+        """
+        exc, exc_type, tb = exc_info
+
+        error_from_exception = registry.get(exc_type, default_error_from_exception)
+        return error_from_exception(exc_info, status, message)
 
     def __str__(self):
         return (
             "<RPC terminated with:\n"
             "\tstatus = {}\n"
+            '\tmessage = "{}"\n'
             '\tdetails = "{}"\n'
-            '\tdebug_error_string = "{}"\n'
-            ">".format(self.status, self.details, self.debug_error_string)
+            ">".format(self.status, self.message, self.details)
         )
+
+
+def register(exc_type, custom_error_from_exception):
+    """ Register a custom implementation to generate a GrpcError from an underlying
+    exception, by exception type.
+
+    Must be a callable with a signature matching `default_error_from_exception`.
+    """
+    registry[exc_type] = custom_error_from_exception
+
+
+def unregister(exc_type):
+    """ Unregister a custom implementation.
+    """
+    registry.pop(exc_type, None)
+
+
+def default_error_from_exception(exc_info, status=None, message=None):
+    """ Create a new GrpcError instance representing an underlying exception.
+    The `status` and `message` can be passed to this function.
+
+    A `google.rpc.Status` message will be generated capturing the debug info of the
+    underyling traceback.
+    """
+    exc, exc_type, tb = exc_info
+
+    detail = Any()
+    detail.Pack(
+        DebugInfo(stack_entries=traceback.format_exception(*exc_info), detail=str(exc),)
+    )
+    status = status or StatusCode.UNKNOWN
+    message = message or str(exc)
+
+    rpc_status = Status(
+        code=STATUS_CODE_TO_CYGRPC_STATUS_CODE[status],
+        message=message,
+        details=[detail],
+    )
+
+    return GrpcError(status=status, message=message, details=rpc_status)

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
+import traceback
+
+from grpc import StatusCode
 from grpc._common import (
     CYGRPC_STATUS_CODE_TO_STATUS_CODE,
     STATUS_CODE_TO_CYGRPC_STATUS_CODE,
 )
-from grpc import StatusCode
+
 from google.protobuf.any_pb2 import Any
 from google.rpc.error_details_pb2 import DebugInfo
 from google.rpc.status_pb2 import Status
-import traceback
+
 
 registry = {}
 
@@ -57,7 +60,7 @@ class GrpcError(Exception):
         This can be overridden by registering a new callable against a given exception
         type. See `register`.
         """
-        exc, exc_type, tb = exc_info
+        exc_type, exc, tb = exc_info
 
         error_from_exception = registry.get(exc_type, default_error_from_exception)
         return error_from_exception(exc_info, status, message)
@@ -94,7 +97,7 @@ def default_error_from_exception(exc_info, status=None, message=None):
     A `google.rpc.Status` message will be generated capturing the debug info of the
     underyling traceback.
     """
-    exc, exc_type, tb = exc_info
+    exc_type, exc, tb = exc_info
 
     detail = Any()
     detail.Pack(

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -81,6 +81,10 @@ class GrpcError(Exception):
         )
 
 
+def make_status(code, message, details=None):
+    return Status(code=code.value[0], message=message, details=details or [])
+
+
 def register_exception_handler(exc_type, custom_error_from_exception):
     """ Register a custom implementation to generate a GrpcError from an underlying
     exception, by exception type.

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -48,6 +48,14 @@ class GrpcError(Exception):
         )
 
     @staticmethod
+    def from_status(status):
+        return GrpcError(
+            code=STATUS_CODE_INT_TO_ENUM_MAP[status.code],
+            message=status.message,
+            status=status,
+        )
+
+    @staticmethod
     def from_exception(exc_info, code=None, message=None):
         """ Utility method to create a new GrpcError instance representing an
         underlying exception. Useful in try/except clauses.

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -103,8 +103,8 @@ def unregister_expection_handler(exc_type):
 def default_error_from_exception(exc_info, code=None, message=None):
     """ Create a new GrpcError instance representing an underlying exception.
 
-    If the `DEBUG` key is set in the Nameko config, the `status` message will capture
-    the underyling traceback in a `google.rpc.error_details.DebugInfo` message.
+    If the `GRPC_DEBUG` key is set in the Nameko config, the `status` message will
+    capture the underyling traceback in a `google.rpc.error_details.DebugInfo` message.
     """
     exc_type, exc, tb = exc_info
 
@@ -113,7 +113,7 @@ def default_error_from_exception(exc_info, code=None, message=None):
 
     status = Status(code=STATUS_CODE_ENUM_TO_INT_MAP[code], message=message)
 
-    if config.get("DEBUG"):
+    if config.get("GRPC_DEBUG"):
         debug_info = Any()
         debug_info.Pack(
             DebugInfo(

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import traceback
 
-from nameko import config
 from grpc import StatusCode
+from nameko import config
 
 from google.protobuf.any_pb2 import Any
 from google.rpc.error_details_pb2 import DebugInfo

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -33,23 +33,23 @@ class GrpcError(Exception):
             headers[GRPC_DETAILS_METADATA_KEY] = self.status.SerializeToString()
         return list(headers.items())
 
-    @staticmethod
-    def from_headers(headers):
+    @classmethod
+    def from_headers(cls, headers):
         """ Rehydrate a new instance from headers received as trailing metadata.
         """
         code = int(headers.get("grpc-status"))
         message = headers.get("grpc-message")
         status = headers.get(GRPC_DETAILS_METADATA_KEY)
 
-        return GrpcError(
+        return cls(
             code=STATUS_CODE_INT_TO_ENUM_MAP[code],
             message=message,
             status=Status.FromString(status) if status else None,
         )
 
-    @staticmethod
-    def from_status(status):
-        return GrpcError(
+    @classmethod
+    def from_status(cls, status):
+        return cls(
             code=STATUS_CODE_INT_TO_ENUM_MAP[status.code],
             message=status.message,
             status=status,

--- a/nameko_grpc/headers.py
+++ b/nameko_grpc/headers.py
@@ -116,6 +116,7 @@ class HeaderManager:
         Overwrites any existing header with the same name. Optionally decodes
         the headers first.
         """
+        # XXX why isn't this clobbered?
         if from_wire:
             headers = self.decode(headers)
         check_decoded(headers)

--- a/nameko_grpc/headers.py
+++ b/nameko_grpc/headers.py
@@ -57,7 +57,9 @@ def decode_header(header):
     name, value = header
     name = name.decode("utf-8")
     if name.endswith("-bin"):
-        value = base64.b64decode(value)
+        value = base64.b64decode(
+            value + b"=="
+        )  # add padding, per https://stackoverflow.com/a/49459036/128749
     else:
         value = value.decode("utf-8")
     return name, value

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,17 @@ setup(
     url="http://github.com/nameko/nameko-grpc",
     packages=find_packages(exclude=["test"]),
     install_requires=["nameko>=3.0.0-rc9", "h2>=3", "grpcio", "protobuf"],
-    extras_require={"dev": ["coverage", "pytest", "grpcio-tools", "wrapt", "zmq"]},
+    extras_require={
+        "dev": [
+            "coverage",
+            "pytest",
+            "grpcio-tools",
+            "grpcio-status",
+            "googleapis-common-protos",
+            "wrapt",
+            "zmq",
+        ]
+    },
     zip_safe=True,
     license="Apache License, Version 2.0",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, "README.md"), "r", "utf-8") as handle:
 
 setup(
     name="nameko-grpc",
-    version="1.4.0",
+    version="1.5.0",
     description="Nameko gRPC extensions",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/test/grpc_indirect_client.py
+++ b/test/grpc_indirect_client.py
@@ -10,7 +10,8 @@ from grpc._cython.cygrpc import CompressionAlgorithm, CompressionLevel
 from nameko_grpc.constants import Cardinality
 from nameko_grpc.errors import GrpcError
 
-from helpers import Command, RemoteClientTransport
+
+from helpers import Command, RemoteClientTransport, status_from_metadata
 
 
 def execute(command, stub):
@@ -45,7 +46,10 @@ def execute(command, stub):
         state = exc._state
         response_metadata["code"] = state.code
         response_metadata["details"] = state.details
-        response = GrpcError(state.code, state.details, state.debug_error_string)
+
+        response = GrpcError(
+            state.code, state.details, status_from_metadata(state.trailing_metadata)
+        )
 
     command.send_response(response)
     command.send_metadata(response_metadata)

--- a/test/grpc_indirect_client.py
+++ b/test/grpc_indirect_client.py
@@ -10,7 +10,6 @@ from grpc._cython.cygrpc import CompressionAlgorithm, CompressionLevel
 from nameko_grpc.constants import Cardinality
 from nameko_grpc.errors import GrpcError
 
-
 from helpers import Command, RemoteClientTransport, status_from_metadata
 
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -5,14 +5,16 @@ import os
 import pickle
 import threading
 import time
-from google.rpc.status_pb2 import Status
+
 import grpc
 import wrapt
 import zmq
+from google.rpc import status_pb2
 
 from nameko_grpc.constants import Cardinality
-from nameko_grpc.errors import GrpcError, GRPC_DETAILS_METADATA_KEY
-from google.rpc import status_pb2
+from nameko_grpc.errors import GRPC_DETAILS_METADATA_KEY, GrpcError
+
+from google.rpc.status_pb2 import Status
 
 
 def make_status(code, message, details=None):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -17,10 +17,6 @@ from nameko_grpc.errors import GRPC_DETAILS_METADATA_KEY, GrpcError
 from google.rpc.status_pb2 import Status
 
 
-def make_status(code, message, details=None):
-    return Status(code=code.value[0], message=message, details=details or [])
-
-
 def status_from_metadata(metadata):
     for key, value in metadata:
         if key == GRPC_DETAILS_METADATA_KEY:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -14,8 +14,6 @@ from google.rpc import status_pb2
 from nameko_grpc.constants import Cardinality
 from nameko_grpc.errors import GRPC_DETAILS_METADATA_KEY, GrpcError
 
-from google.rpc.status_pb2 import Status
-
 
 def status_from_metadata(metadata):
     for key, value in metadata:

--- a/test/spec/example.proto
+++ b/test/spec/example.proto
@@ -10,6 +10,8 @@ service example {
   rpc not_found (ExampleRequest) returns (ExampleReply) {}
   rpc unary_error (ExampleRequest) returns (ExampleReply) {}
   rpc stream_error (ExampleRequest) returns (stream ExampleReply) {}
+  rpc unary_error_via_context (ExampleRequest) returns (ExampleReply) {}
+  rpc stream_error_via_context (ExampleRequest) returns (stream ExampleReply) {}
 }
 
 

--- a/test/spec/example.proto
+++ b/test/spec/example.proto
@@ -12,6 +12,8 @@ service example {
   rpc stream_error (ExampleRequest) returns (stream ExampleReply) {}
   rpc unary_error_via_context (ExampleRequest) returns (ExampleReply) {}
   rpc stream_error_via_context (ExampleRequest) returns (stream ExampleReply) {}
+  rpc unary_grpc_error (ExampleRequest) returns (ExampleReply) {}
+  rpc stream_grpc_error (ExampleRequest) returns (stream ExampleReply) {}
 }
 
 

--- a/test/spec/example_grpc.py
+++ b/test/spec/example_grpc.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 from grpc_status import rpc_status
-from nameko_grpc.errors import make_status, StatusCode
 
-from helpers import (
-    extract_metadata,
-    instrumented,
-    maybe_echo_metadata,
-    maybe_sleep,
-)
+from nameko_grpc.errors import StatusCode, make_status
+
+from helpers import extract_metadata, instrumented, maybe_echo_metadata, maybe_sleep
 
 import example_pb2_grpc
 from example_pb2 import ExampleReply

--- a/test/spec/example_grpc.py
+++ b/test/spec/example_grpc.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-from helpers import extract_metadata, instrumented, maybe_echo_metadata, maybe_sleep
 from grpc import StatusCode
+
+from helpers import extract_metadata, instrumented, maybe_echo_metadata, maybe_sleep
+
 import example_pb2_grpc
 from example_pb2 import ExampleReply
 

--- a/test/spec/example_grpc.py
+++ b/test/spec/example_grpc.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 from grpc import StatusCode
+from grpc_status import rpc_status
 
 from helpers import (
-    make_status,
     extract_metadata,
     instrumented,
+    make_status,
     maybe_echo_metadata,
     maybe_sleep,
 )
 
 import example_pb2_grpc
 from example_pb2 import ExampleReply
-from grpc_status import rpc_status
 
 
 class Error(Exception):

--- a/test/spec/example_grpc.py
+++ b/test/spec/example_grpc.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-from grpc import StatusCode
 from grpc_status import rpc_status
+from nameko_grpc.errors import make_status, StatusCode
 
 from helpers import (
     extract_metadata,
     instrumented,
-    make_status,
     maybe_echo_metadata,
     maybe_sleep,
 )

--- a/test/spec/example_nameko.py
+++ b/test/spec/example_nameko.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from grpc import StatusCode
+
 from nameko_grpc.entrypoint import Grpc
 from nameko_grpc.errors import GrpcError
-
-from grpc import StatusCode
 
 from helpers import extract_metadata, instrumented, maybe_echo_metadata, maybe_sleep
 

--- a/test/spec/example_nameko.py
+++ b/test/spec/example_nameko.py
@@ -2,11 +2,12 @@
 from grpc import StatusCode
 
 from nameko_grpc.entrypoint import Grpc
-from nameko_grpc.errors import GrpcError, GRPC_DETAILS_METADATA_KEY
+from nameko_grpc.errors import GRPC_DETAILS_METADATA_KEY, GrpcError
+
 from helpers import (
-    make_status,
     extract_metadata,
     instrumented,
+    make_status,
     maybe_echo_metadata,
     maybe_sleep,
 )

--- a/test/spec/example_nameko.py
+++ b/test/spec/example_nameko.py
@@ -7,12 +7,7 @@ from nameko_grpc.errors import (
     make_status,
 )
 
-from helpers import (
-    extract_metadata,
-    instrumented,
-    maybe_echo_metadata,
-    maybe_sleep,
-)
+from helpers import extract_metadata, instrumented, maybe_echo_metadata, maybe_sleep
 
 import example_pb2_grpc
 from example_pb2 import ExampleReply

--- a/test/spec/example_nameko.py
+++ b/test/spec/example_nameko.py
@@ -70,7 +70,7 @@ class example:
     @grpc
     @instrumented
     def unary_error_via_context(self, request, context):
-        context.set_code(StatusCode.UNAUTHENTICATED.value[0])
+        context.set_code(StatusCode.UNAUTHENTICATED)
         context.set_message("Not allowed!")
 
     @grpc(expected_exceptions=Error)
@@ -94,7 +94,7 @@ class example:
             maybe_sleep(request)
             # break on the last message
             if i == request.response_count - 1:
-                context.set_code(StatusCode.RESOURCE_EXHAUSTED.value[0])
+                context.set_code(StatusCode.RESOURCE_EXHAUSTED)
                 context.set_message("Out of tokens!")
                 break
             yield ExampleReply(message=message, seqno=i + 1)

--- a/test/spec/example_nameko.py
+++ b/test/spec/example_nameko.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
-from grpc import StatusCode
-
 from nameko_grpc.entrypoint import Grpc
-from nameko_grpc.errors import GRPC_DETAILS_METADATA_KEY, GrpcError
+from nameko_grpc.errors import (
+    GRPC_DETAILS_METADATA_KEY,
+    GrpcError,
+    StatusCode,
+    make_status,
+)
 
 from helpers import (
     extract_metadata,
     instrumented,
-    make_status,
     maybe_echo_metadata,
     maybe_sleep,
 )

--- a/test/spec/interop_nameko.py
+++ b/test/spec/interop_nameko.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from nameko_grpc.entrypoint import Grpc
+from nameko_grpc.errors import STATUS_CODE_INT_TO_ENUM_MAP
 
 import empty_pb2
 import interop_pb2_grpc
@@ -33,8 +34,9 @@ def _maybe_echo_metadata(servicer_context):
 def _maybe_echo_status_and_message(request, servicer_context):
     """Sets the response context code and details if the request asks for them"""
     if request.HasField("response_status"):
-        servicer_context.set_code(request.response_status.code)
-        servicer_context.set_details(request.response_status.message)
+        code = STATUS_CODE_INT_TO_ENUM_MAP[request.response_status.code]
+        servicer_context.set_code(code)
+        servicer_context.set_message(request.response_status.message)
 
 
 class TestService:

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -184,7 +184,7 @@ class TestCompression:
                 protobufs.ExampleRequest(value="A" * 1000), compression="gzip"
             )
         assert error.value.status == StatusCode.UNIMPLEMENTED
-        assert error.value.details == "Algorithm not supported: gzip"
+        assert error.value.message == "Algorithm not supported: gzip"
 
         res = client.unary_stream(
             protobufs.ExampleRequest(value="A" * 1000, response_count=2),
@@ -193,7 +193,7 @@ class TestCompression:
         with pytest.raises(GrpcError) as error:
             list(res)
         assert error.value.status == StatusCode.UNIMPLEMENTED
-        assert error.value.details == "Algorithm not supported: gzip"
+        assert error.value.message == "Algorithm not supported: gzip"
 
         def generate_requests():
             for value in ["A" * 1000, "B" * 1000]:
@@ -202,7 +202,7 @@ class TestCompression:
         with pytest.raises(GrpcError) as error:
             client.stream_unary(generate_requests(), compression="gzip")
         assert error.value.status == StatusCode.UNIMPLEMENTED
-        assert error.value.details == "Algorithm not supported: gzip"
+        assert error.value.message == "Algorithm not supported: gzip"
 
         def generate_requests():
             for value in ["A" * 1000, "B" * 1000]:
@@ -212,7 +212,7 @@ class TestCompression:
         with pytest.raises(GrpcError) as error:
             next(res)
         assert error.value.status == StatusCode.UNIMPLEMENTED
-        assert error.value.details == "Algorithm not supported: gzip"
+        assert error.value.message == "Algorithm not supported: gzip"
 
     def test_compression_not_required_at_client(self):
         # TODO

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -183,7 +183,7 @@ class TestCompression:
             client.unary_unary(
                 protobufs.ExampleRequest(value="A" * 1000), compression="gzip"
             )
-        assert error.value.status == StatusCode.UNIMPLEMENTED
+        assert error.value.code == StatusCode.UNIMPLEMENTED
         assert error.value.message == "Algorithm not supported: gzip"
 
         res = client.unary_stream(
@@ -192,7 +192,7 @@ class TestCompression:
         )
         with pytest.raises(GrpcError) as error:
             list(res)
-        assert error.value.status == StatusCode.UNIMPLEMENTED
+        assert error.value.code == StatusCode.UNIMPLEMENTED
         assert error.value.message == "Algorithm not supported: gzip"
 
         def generate_requests():
@@ -201,7 +201,7 @@ class TestCompression:
 
         with pytest.raises(GrpcError) as error:
             client.stream_unary(generate_requests(), compression="gzip")
-        assert error.value.status == StatusCode.UNIMPLEMENTED
+        assert error.value.code == StatusCode.UNIMPLEMENTED
         assert error.value.message == "Algorithm not supported: gzip"
 
         def generate_requests():
@@ -211,7 +211,7 @@ class TestCompression:
         res = client.stream_stream(generate_requests(), compression="gzip")
         with pytest.raises(GrpcError) as error:
             next(res)
-        assert error.value.status == StatusCode.UNIMPLEMENTED
+        assert error.value.code == StatusCode.UNIMPLEMENTED
         assert error.value.message == "Algorithm not supported: gzip"
 
     def test_compression_not_required_at_client(self):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -177,6 +177,7 @@ class TestRaiseGrpcError:
             client.unary_grpc_error(protobufs.ExampleRequest(value="A"))
         assert error.value.code == StatusCode.UNAUTHENTICATED
         assert error.value.message == "Not allowed!"
+        assert isinstance(error.value.status, Status)
 
     def test_error_while_streaming_response(self, client, protobufs):
         res = client.stream_grpc_error(
@@ -194,6 +195,7 @@ class TestRaiseGrpcError:
 
         assert error.value.code == StatusCode.RESOURCE_EXHAUSTED
         assert error.value.message == "Out of tokens!"
+        assert isinstance(error.value.status, Status)
 
 
 @pytest.mark.equivalence
@@ -203,8 +205,10 @@ class TestErrorViaContext:
             client.unary_error_via_context(protobufs.ExampleRequest(value="A"))
         assert error.value.code == StatusCode.UNAUTHENTICATED
         assert error.value.message == "Not allowed!"
+        assert isinstance(error.value.status, Status)
 
     def test_error_while_streaming_response(self, client, protobufs):
+
         res = client.stream_error_via_context(
             protobufs.ExampleRequest(value="A", response_count=10)
         )
@@ -220,6 +224,7 @@ class TestErrorViaContext:
 
         assert error.value.code == StatusCode.RESOURCE_EXHAUSTED
         assert error.value.message == "Out of tokens!"
+        assert isinstance(error.value.status, Status)
 
 
 class TestErrorDetails:
@@ -272,10 +277,6 @@ class TestErrorDetails:
 
 
 class TestCustomErrorFromException:
-    @pytest.fixture(params=["client=nameko", "client=dp"])
-    def client_type(self, request):
-        return request.param[7:]
-
     @pytest.fixture(params=["server=nameko"])
     def server_type(self, request):
         return request.param[7:]

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -6,16 +6,13 @@ import time
 
 import pytest
 from grpc import StatusCode
-from nameko_grpc.errors import (
-    STATUS_CODE_INT_TO_ENUM_MAP,
-    STATUS_CODE_ENUM_TO_INT_MAP,
-)
-from google.rpc.status_pb2 import Status
+
 from nameko_grpc.constants import Cardinality
-from nameko_grpc.errors import GrpcError
+from nameko_grpc.errors import STATUS_CODE_ENUM_TO_INT_MAP, GrpcError, register
+
 from google.protobuf.any_pb2 import Any
 from google.rpc.error_details_pb2 import DebugInfo
-from nameko_grpc.errors import register
+from google.rpc.status_pb2 import Status
 
 
 @pytest.mark.equivalence

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -6,9 +6,9 @@ import time
 
 import pytest
 from grpc import StatusCode
-from grpc._common import (
-    CYGRPC_STATUS_CODE_TO_STATUS_CODE,
-    STATUS_CODE_TO_CYGRPC_STATUS_CODE,
+from nameko_grpc.errors import (
+    STATUS_CODE_INT_TO_ENUM_MAP,
+    STATUS_CODE_ENUM_TO_INT_MAP,
 )
 from google.rpc.status_pb2 import Status
 from nameko_grpc.constants import Cardinality
@@ -261,7 +261,7 @@ class TestCustomErrorFromException:
             message = "Not allowed!"
 
             status = Status(
-                code=STATUS_CODE_TO_CYGRPC_STATUS_CODE[code],
+                code=STATUS_CODE_ENUM_TO_INT_MAP[code],
                 message=message,
                 details=[],  # don't include traceback
             )

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -8,7 +8,11 @@ import pytest
 from grpc import StatusCode
 
 from nameko_grpc.constants import Cardinality
-from nameko_grpc.errors import STATUS_CODE_ENUM_TO_INT_MAP, GrpcError, register
+from nameko_grpc.errors import (
+    STATUS_CODE_ENUM_TO_INT_MAP,
+    GrpcError,
+    register_exception_handler,
+)
 
 from google.protobuf.any_pb2 import Any
 from google.rpc.error_details_pb2 import DebugInfo
@@ -294,7 +298,7 @@ class TestCustomErrorFromException:
 
             return GrpcError(code=code, message=message, status=status)
 
-        register(Error, handler)
+        register_exception_handler(Error, handler)
 
     def test_error_before_response(self, client, protobufs):
         with pytest.raises(GrpcError) as error:

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -6,8 +6,8 @@ import time
 
 import pytest
 from grpc import StatusCode
-
 from nameko import config
+
 from nameko_grpc.constants import Cardinality
 from nameko_grpc.errors import (
     STATUS_CODE_ENUM_TO_INT_MAP,

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -239,7 +239,7 @@ class TestErrorDetails:
 
     @pytest.fixture(params=[True, False])
     def debug_mode(self, request):
-        with config.patch({"DEBUG": request.param}):
+        with config.patch({"GRPC_DEBUG": request.param}):
             yield request.param
 
     def unpack_debug_info(self, detail):

--- a/test/test_headers.py
+++ b/test/test_headers.py
@@ -33,6 +33,13 @@ class TestDecodeHeader:
             b"123",
         )
 
+    def test_binary_with_truncated_padding(self):
+        padded_value = base64.b64encode(b"1234")
+        assert padded_value.endswith(b"=")
+
+        trimmed_value = padded_value[:-2]
+        assert decode_header((b"foo-bin", trimmed_value)) == ("foo-bin", b"1234",)
+
     def test_string_value(self):
         assert decode_header((b"foo", b"123")) == ("foo", "123")
 

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -113,7 +113,7 @@ class TestStreamBase:
 
     def test_close_with_error(self):
         stream = StreamBase(1)
-        error = GrpcError("boom", "details", "error string")
+        error = GrpcError("boom", "details")
         stream.close(error)
 
         assert stream.closed
@@ -169,7 +169,7 @@ class TestReceiveStream:
 
     def test_consume_grpc_error(self):
         stream = ReceiveStream(1)
-        error = GrpcError("boom", "details", "message")
+        error = GrpcError("boom", "details")
         stream.queue.put(error)
 
         message_type = Mock()
@@ -354,7 +354,7 @@ class TestSendStreamFlushQueueToBuffer:
     def test_error_on_queue(self, generate_messages):
         stream = SendStream(1)
 
-        error = GrpcError("boom", "details", "error string")
+        error = GrpcError("boom", "details")
         messages = itertools.chain(generate_messages(count=2, length=20), [error])
 
         stream.populate(messages)
@@ -435,7 +435,7 @@ class TestSendStreamRead:
     def test_stream_closed_with_error(self):
         stream = SendStream(1)
 
-        error = GrpcError("boom", "details", "error string")
+        error = GrpcError("boom", "details")
         stream.close(error)
 
         max_bytes = 10


### PR DESCRIPTION
Prior to this PR, nameko-grpc supported the same error-raising capabilities as the official gRPC python client:

1. Raising an exception in the endpoint resulted in a status of UNKNOWN with a message "Exception calling application: {str(exc)}"
2. Status code and message could be set using the `context` object and the service method should return without exception

This PR adds enhanced error handling as detailed in the README included in the PR. In summary:

* The default behaviour is changed to follow the [recommended practise](https://kccncna17.sched.com/event/CU7e/modifying-grpc-services-over-time-i-eric-anderson-google) of including a `google.rpc.status.Status` protobuf message when returning gRPC errors. This currently includes the traceback in a nested `google.rpc.error_status.DebugInfo` object if a `DEBUG` key is set in Nameko config (at the top level, which might not be the best place to check)
* The interface of the `nameko_grpc.errors.GrpcError` object is changed to reflect gRPC naming:
  - status -> code (a `grpc.StatusCode` value)
  - details -> message (still a string)
  - debug_error_string -> status (a `google.rpc.status.Status` object)
* It is possible to register exception handlers to map specific exception types to `GrpcError` objects, so that we can return rich gRPC errors even from service methods that return vanilla exceptions.

The changes to the `GrpcError` object are backwards-incompatible for any service code or extensions dealing with this object directly.