### PR TITLE
Close sockets on client shutdown

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
 
     - name: start rabbitmq
       run: |
-        docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3-management
+        docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3.8-management
 
     - name: install test dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ static:
 	pre-commit run --all-files
 
 test:
-	py.test test -v
+	py.test test -v --timeout 30
 
 coverage:
 	coverage run -m pytest test -v

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ static:
 	pre-commit run --all-files
 
 test:
-	py.test test -v --timeout 30
+	py.test test -v --timeout 120
 
 coverage:
 	coverage run -m pytest test -v

--- a/nameko_grpc/connection.py
+++ b/nameko_grpc/connection.py
@@ -94,6 +94,7 @@ class ConnectionManager:
                     f"{f' with error {error}' if error else ''}."
                 )
                 receive_stream.close(error)
+            self.sock.close()
             self.stopped.set()
 
     def run_forever(self):
@@ -143,7 +144,6 @@ class ConnectionManager:
     def stop(self):
         self.run = False
         self.stopped.wait()
-        self.sock.close()
 
     def on_iteration(self):
         """ Called on every iteration of the event loop.

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
             "grpcio-tools",
             "grpcio-status",
             "googleapis-common-protos",
+            "objgraph",
             "wrapt",
             "zmq",
         ]

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "dev": [
             "coverage",
             "pytest",
+            "pytest-timeout",
             "grpcio-tools",
             "grpcio-status",
             "googleapis-common-protos",

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,0 +1,32 @@
+import pytest
+import objgraph
+from nameko_grpc.client import Client
+from nameko.testing.waiting import wait_for_call
+
+
+class TestCloseSocketOnClientExit:
+    @pytest.fixture(params=["server=nameko"])
+    def server_type(self, request):
+        return request.param[7:]
+
+    def test_close_socket(self, server, load_stubs, spec_dir, grpc_port, protobufs):
+        """ Regression test for https://github.com/nameko/nameko-grpc/issues/39
+        """
+        stubs = load_stubs("example")
+
+        client = Client(
+            "//localhost:{}".format(grpc_port),
+            stubs.exampleStub,
+            "none",
+            "high",
+            False,
+        )
+        proxy = client.start()
+
+        connection = objgraph.by_type("ServerConnectionManager")[0]
+
+        response = proxy.unary_unary(protobufs.ExampleRequest(value="A"))
+        assert response.message == "A"
+
+        with wait_for_call(connection.sock, "close"):
+            client.stop()

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import objgraph
 import pytest
+from nameko.testing.utils import get_extension
 from nameko.testing.waiting import wait_for_call
 
 from nameko_grpc.client import Client
+from nameko_grpc.entrypoint import GrpcServer
 
 
 class TestCloseSocketOnClientExit:
@@ -25,7 +26,9 @@ class TestCloseSocketOnClientExit:
         )
         proxy = client.start()
 
-        connection = objgraph.by_type("ServerConnectionManager")[0]
+        container = server
+        grpc_server = get_extension(container, GrpcServer)
+        connection = grpc_server.channel.conn_pool.connections.queue[0]
 
         response = proxy.unary_unary(protobufs.ExampleRequest(value="A"))
         assert response.message == "A"

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,7 +1,9 @@
-import pytest
+# -*- coding: utf-8 -*-
 import objgraph
-from nameko_grpc.client import Client
+import pytest
 from nameko.testing.waiting import wait_for_call
+
+from nameko_grpc.client import Client
 
 
 class TestCloseSocketOnClientExit:


### PR DESCRIPTION
Fixes #39.

Simple solution: close the socket as soon as the connection manager exits.