### PR TITLE
Performance tweaks

### DIFF
--- a/nameko_grpc/inspection.py
+++ b/nameko_grpc/inspection.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import importlib
 import inspect
+from functools import lru_cache
 
 from google.protobuf import descriptor
 from mock import Mock
@@ -8,6 +9,7 @@ from mock import Mock
 from nameko_grpc.constants import Cardinality
 
 
+@lru_cache()
 class Inspector:
     _stub_module = None
     _protobufs_module = None

--- a/test/spec/performance_grpc.py
+++ b/test/spec/performance_grpc.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+Usage: python performance_grpc.py
+"""
+import grpc
+from concurrent import futures
+import time
+
+example_pb2, example_pb2_grpc = grpc.protos_and_services("example.proto")
+
+PORT = 50052
+_ONE_DAY_IN_SECONDS = 60 * 60 * 24
+
+
+class example(example_pb2_grpc.exampleServicer):
+    def unary_unary(self, request, context):
+        message = request.value * (request.multiplier or 1)
+        return example_pb2.ExampleReply(message=message)
+
+    def unary_stream(self, request, context):
+        message = request.value * (request.multiplier or 1)
+        for i in range(request.response_count):
+            yield example_pb2.ExampleReply(message=message, seqno=i + 1)
+
+    def stream_unary(self, request, context):
+        messages = []
+        for index, req in enumerate(request):
+            message = req.value * (req.multiplier or 1)
+            messages.append(message)
+
+        return example_pb2.ExampleReply(message=",".join(messages))
+
+    def stream_stream(self, request, context):
+        for index, req in enumerate(request):
+            message = req.value * (req.multiplier or 1)
+            yield example_pb2.ExampleReply(message=message, seqno=index + 1)
+
+
+def serve():
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    example_pb2_grpc.add_exampleServicer_to_server(example(), server)
+    server.add_insecure_port("[::]:{}".format(PORT))
+
+    server.start()
+    try:
+        while True:
+            time.sleep(_ONE_DAY_IN_SECONDS)
+    except KeyboardInterrupt:
+        server.stop(0)
+
+
+serve()

--- a/test/spec/performance_grpc.py
+++ b/test/spec/performance_grpc.py
@@ -2,9 +2,11 @@
 """
 Usage: python performance_grpc.py
 """
-import grpc
-from concurrent import futures
 import time
+from concurrent import futures
+
+import grpc
+
 
 example_pb2, example_pb2_grpc = grpc.protos_and_services("example.proto")
 

--- a/test/spec/performance_nameko.py
+++ b/test/spec/performance_nameko.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+Usage: nameko run performance_nameko
+"""
+import grpc
+from nameko_grpc.entrypoint import Grpc
+
+example_pb2, example_pb2_grpc = grpc.protos_and_services("example.proto")
+entrypoint = Grpc.implementing(example_pb2_grpc.exampleStub)
+
+
+class example:
+    name = "example"
+
+    @entrypoint
+    def unary_unary(self, request, context):
+        message = request.value * (request.multiplier or 1)
+        return example_pb2.ExampleReply(message=message)
+
+    @entrypoint
+    def unary_stream(self, request, context):
+        message = request.value * (request.multiplier or 1)
+        for i in range(request.response_count):
+            yield example_pb2.ExampleReply(message=message, seqno=i + 1)
+
+    @entrypoint
+    def stream_unary(self, request, context):
+        messages = []
+        for index, req in enumerate(request):
+            message = req.value * (req.multiplier or 1)
+            messages.append(message)
+
+        return example_pb2.ExampleReply(message=",".join(messages))
+
+    @entrypoint
+    def stream_stream(self, request, context):
+        for index, req in enumerate(request):
+            message = req.value * (req.multiplier or 1)
+            yield example_pb2.ExampleReply(message=message, seqno=index + 1)

--- a/test/spec/performance_nameko.py
+++ b/test/spec/performance_nameko.py
@@ -3,7 +3,9 @@
 Usage: nameko run performance_nameko
 """
 import grpc
+
 from nameko_grpc.entrypoint import Grpc
+
 
 example_pb2, example_pb2_grpc = grpc.protos_and_services("example.proto")
 entrypoint = Grpc.implementing(example_pb2_grpc.exampleStub)

--- a/test/test_inspection.py
+++ b/test/test_inspection.py
@@ -40,3 +40,10 @@ class TestInspection:
         assert insp.cardinality_for_method("unary_stream") == Cardinality.UNARY_STREAM
         assert insp.cardinality_for_method("stream_unary") == Cardinality.STREAM_UNARY
         assert insp.cardinality_for_method("stream_stream") == Cardinality.STREAM_STREAM
+
+    def test_cache_is_keyed_on_stub(self, load_stubs):
+        inspector1 = Inspector(load_stubs("example").exampleStub)
+        inspector2 = Inspector(load_stubs("advanced").advancedStub)
+
+        assert inspector1.service_name == "nameko.example"
+        assert inspector2.service_name == "nameko.advanced"


### PR DESCRIPTION
I have used https://ghz.sh to assess the performance of nameko-grpc compared to the official gRPC implementation, and also inspected where the service was spending its time using https://github.com/benfred/py-spy.

The test is against a trivial unary request and response endpoint that does almost nothing in the service method. The work on the server is almost exclusively overhead of handling requests.

Results below, but TL;DR:

- As of 1.2.0rc nameko-grpc was about 15x slower than the official Python gRPC implementation
- An enormous amount of time was spent re-generating the Inspector object in each request 🙈 
- Adding a trivial cache to this brings nameko-grpc improves performance by a factor of 7, to just shy of 2x slower than the official implementation 

Two scripts used to run the services under test are included in this PR.

### gRPC official client

```
╰─ ghz -n 10000 --insecure --proto ./example.proto --call nameko.example.unary_unary -d '{"value": "A"}' localhost:50052

Summary:
  Count:	10000
  Total:	2.42 s
  Slowest:	23.14 ms
  Fastest:	6.23 ms
  Average:	12.06 ms
  Requests/sec:	4124.18

Response time histogram:
  6.231 [1]	|
  7.922 [8]	|
  9.613 [644]	|∎∎∎∎∎∎∎
  11.304 [3455]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  12.995 [3157]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  14.686 [1684]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  16.377 [759]	|∎∎∎∎∎∎∎∎∎
  18.068 [184]	|∎∎
  19.759 [29]	|
  21.450 [64]	|∎
  23.141 [15]	|

Latency distribution:
  10 % in 9.80 ms
  25 % in 10.58 ms
  50 % in 11.71 ms
  75 % in 13.18 ms
  90 % in 14.77 ms
  95 % in 15.62 ms
  99 % in 18.22 ms

Status code distribution:
  [OK]   10000 responses
```

### Nameko, without changes in this PR:

```
╰─ ghz -n 10000 --insecure --proto ./example.proto --call nameko.example.unary_unary -d '{"value": "A"}' localhost:50051

Summary:
  Count:	10000
  Total:	34.89 s
  Slowest:	410.23 ms
  Fastest:	90.82 ms
  Average:	174.09 ms
  Requests/sec:	286.59

Response time histogram:
  90.822 [1]	|
  122.762 [245]	|∎∎∎
  154.703 [3831]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  186.643 [1613]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  218.584 [3244]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  250.524 [736]	|∎∎∎∎∎∎∎∎
  282.465 [199]	|∎∎
  314.405 [51]	|∎
  346.346 [50]	|∎
  378.286 [18]	|
  410.227 [12]	|

Latency distribution:
  10 % in 126.87 ms
  25 % in 135.98 ms
  50 % in 181.42 ms
  75 % in 199.73 ms
  90 % in 220.07 ms
  95 % in 236.44 ms
  99 % in 297.01 ms

Status code distribution:
  [OK]   10000 responses

```

![before-change](https://user-images.githubusercontent.com/107611/128251601-9cd9435a-1087-4303-89da-67373ef0b470.png)

### Nameko, with a cached inspector as in this PR

```
╰─ ghz -n 10000 --insecure --proto ./example.proto --call nameko.example.unary_unary -d '{"value": "A"}' localhost:50051

Summary:
  Count:	10000
  Total:	7.54 s
  Slowest:	67.94 ms
  Fastest:	15.51 ms
  Average:	37.41 ms
  Requests/sec:	1326.62

Response time histogram:
  15.506 [1]	|
  20.750 [12]	|
  25.993 [98]	|∎
  31.237 [81]	|∎
  36.480 [4513]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  41.724 [4449]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  46.967 [459]	|∎∎∎∎
  52.211 [280]	|∎∎
  57.454 [49]	|
  62.698 [0]	|
  67.941 [58]	|∎

Latency distribution:
  10 % in 34.13 ms
  25 % in 35.41 ms
  50 % in 36.66 ms
  75 % in 38.55 ms
  90 % in 41.04 ms
  95 % in 46.55 ms
  99 % in 52.53 ms

Status code distribution:
  [OK]   10000 responses
```

![after-change](https://user-images.githubusercontent.com/107611/128251575-5701e939-b934-4a17-b31c-0bb069064ebb.png)

