### PR TITLE
Fix fatal errors during request parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.3.0
     hooks:
     -   id: trailing-whitespace
@@ -12,6 +12,6 @@ repos:
     hooks:
     - id: isort
 -   repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.10.0
     hooks:
     - id: black

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ static:
 	pre-commit run --all-files
 
 test:
-	py.test test -v --timeout 120
+	nameko test test -v --timeout 120
 
 coverage:
-	coverage run -m pytest test -v
+	coverage run -m nameko test test -v
 	coverage report

--- a/nameko_grpc/channel.py
+++ b/nameko_grpc/channel.py
@@ -16,7 +16,7 @@ CONNECT_TIMEOUT = 5
 
 
 class ClientConnectionPool:
-    """ Simple connection pool for clients.
+    """Simple connection pool for clients.
 
     Accepts a list of targets and will maintain a connection to each of them,
     round-robining requests between them.
@@ -87,7 +87,7 @@ class ClientConnectionPool:
 
 
 class ClientChannel:
-    """ Simple client channel.
+    """Simple client channel.
 
     Channels could eventually suppport pluggable resolvers and load-balancing.
     """
@@ -106,7 +106,7 @@ class ClientChannel:
 
 
 class ServerConnectionPool:
-    """ Simple connection pool for servers.
+    """Simple connection pool for servers.
 
     Just accepts new connections and allows them to run until close.
     """
@@ -127,7 +127,9 @@ class ServerConnectionPool:
         if self.ssl:
             context = self.ssl.server_context()
             sock = context.wrap_socket(
-                sock=sock, server_side=True, suppress_ragged_eofs=True,
+                sock=sock,
+                server_side=True,
+                suppress_ragged_eofs=True,
             )
 
         return sock
@@ -161,8 +163,7 @@ class ServerConnectionPool:
 
 
 class ServerChannel:
-    """ Simple server channel encapsulating incoming connection management.
-    """
+    """Simple server channel encapsulating incoming connection management."""
 
     def __init__(self, host, port, ssl, spawn_thread, handle_request):
         self.conn_pool = ServerConnectionPool(

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -176,8 +176,7 @@ class ClientBase:
 
 
 class Client(ClientBase):
-    """ Standalone gRPC client that uses native threads.
-    """
+    """Standalone gRPC client that uses native threads."""
 
     def __enter__(self):
         return self.start()

--- a/nameko_grpc/connection.py
+++ b/nameko_grpc/connection.py
@@ -72,7 +72,8 @@ class ConnectionManager:
             yield
         except Exception:
             log.info(
-                "ConnectionManager shutting down with error. Traceback:", exc_info=True,
+                "ConnectionManager shutting down with error. Traceback:",
+                exc_info=True,
             )
             error = GrpcError.from_exception(
                 sys.exc_info(), code=StatusCode.UNAVAILABLE
@@ -98,8 +99,7 @@ class ConnectionManager:
             self.stopped.set()
 
     def run_forever(self):
-        """ Event loop.
-        """
+        """Event loop."""
         self.conn.initiate_connection()
 
         with self.cleanup_on_exit():
@@ -146,7 +146,7 @@ class ConnectionManager:
         self.stopped.wait()
 
     def on_iteration(self):
-        """ Called on every iteration of the event loop.
+        """Called on every iteration of the event loop.
 
         If there are any open `SendStream`s with headers or data to send, try to send
         them.
@@ -156,14 +156,14 @@ class ConnectionManager:
             self.send_data(stream_id)
 
     def request_received(self, event):
-        """ Called when a request is received on a stream.
+        """Called when a request is received on a stream.
 
         Subclasses should extend this method to handle the request accordingly.
         """
         log.debug("request received, stream %s", event.stream_id)
 
     def response_received(self, event):
-        """ Called when a response is received on a stream.
+        """Called when a response is received on a stream.
 
         Subclasses should extend this method to handle the response accordingly.
         """
@@ -175,7 +175,7 @@ class ConnectionManager:
         receive_stream.headers.set(*event.headers, from_wire=True)
 
     def data_received(self, event):
-        """ Called when data is received on a stream.
+        """Called when data is received on a stream.
 
         If there is any open `ReceiveStream`, write the data to it.
         """
@@ -194,7 +194,7 @@ class ConnectionManager:
         self.conn.acknowledge_received_data(event.flow_controlled_length, stream_id)
 
     def window_updated(self, event):
-        """ Called when the flow control window for a stream is changed.
+        """Called when the flow control window for a stream is changed.
 
         Any data waiting to be sent on the stream may fit in the window now.
         """
@@ -202,7 +202,7 @@ class ConnectionManager:
         self.send_data(event.stream_id)
 
     def stream_ended(self, event):
-        """ Called when an incoming stream ends.
+        """Called when an incoming stream ends.
 
         Close any `ReceiveStream` that was opened for this stream.
         """
@@ -212,7 +212,7 @@ class ConnectionManager:
             receive_stream.close()
 
     def stream_reset(self, event):
-        """ Called when an incoming stream is reset.
+        """Called when an incoming stream is reset.
 
         Close any `ReceiveStream` that was opened for this stream.
         """
@@ -240,7 +240,7 @@ class ConnectionManager:
         self.run = False
 
     def send_headers(self, stream_id, immediate=False):
-        """ Attempt to send any headers on a stream.
+        """Attempt to send any headers on a stream.
 
         Streams determine when headers should be sent. By default headers are not
         returned until there is also data ready to be sent. This can be overriddden
@@ -256,7 +256,7 @@ class ConnectionManager:
             self.conn.send_headers(stream_id, headers, end_stream=False)
 
     def send_data(self, stream_id):
-        """ Attempt to send any pending data on a stream.
+        """Attempt to send any pending data on a stream.
 
         Up to the current flow-control window size bytes may be sent.
 
@@ -290,8 +290,7 @@ class ConnectionManager:
             self.end_stream(stream_id)
 
     def end_stream(self, stream_id):
-        """ Close an outbound stream, sending any trailers.
-        """
+        """Close an outbound stream, sending any trailers."""
         send_stream = self.send_streams.pop(stream_id)
 
         try:
@@ -319,13 +318,12 @@ class ClientConnectionManager(ConnectionManager):
         self.counter = itertools.count(start=1, step=2)
 
     def on_iteration(self):
-        """ On each iteration of the event loop, also initiate any pending requests.
-        """
+        """On each iteration of the event loop, also initiate any pending requests."""
         self.send_pending_requests()
         super().on_iteration()
 
     def send_request(self, request_headers):
-        """ Called by the client to invoke a GRPC method.
+        """Called by the client to invoke a GRPC method.
 
         Establish a `SendStream` to send the request payload and `ReceiveStream`
         for receiving the eventual response. `SendStream` and `ReceiveStream` are
@@ -348,7 +346,7 @@ class ClientConnectionManager(ConnectionManager):
         return request_stream, response_stream
 
     def response_received(self, event):
-        """ Called when a response is received on a stream.
+        """Called when a response is received on a stream.
 
         If the headers contain an error, we should raise it here.
         """
@@ -368,7 +366,7 @@ class ClientConnectionManager(ConnectionManager):
             del self.receive_streams[stream_id]
 
     def trailers_received(self, event):
-        """ Called when trailers are received on a stream.
+        """Called when trailers are received on a stream.
 
         If the trailers contain an error, we should raise it here.
         """
@@ -388,7 +386,7 @@ class ClientConnectionManager(ConnectionManager):
             del self.receive_streams[stream_id]
 
     def send_pending_requests(self):
-        """ Initiate requests for any pending invocations.
+        """Initiate requests for any pending invocations.
 
         Sends initial headers and any request data that is ready to be sent.
         """
@@ -434,7 +432,7 @@ class ServerConnectionManager(ConnectionManager):
         self.handle_request = handle_request
 
     def request_received(self, event):
-        """ Receive a GRPC request and pass it to the GrpcServer to fire any
+        """Receive a GRPC request and pass it to the GrpcServer to fire any
         appropriate entrypoint.
 
         Establish a `ReceiveStream` to receive the request payload and `SendStream`

--- a/nameko_grpc/context.py
+++ b/nameko_grpc/context.py
@@ -18,7 +18,7 @@ def decode_value(value):
 
 
 def metadata_from_context_data(data):
-    """ Utility function transforming a `data` dictionary into metadata suitable
+    """Utility function transforming a `data` dictionary into metadata suitable
     for a GRPC stream.
     """
     metadata = []
@@ -30,7 +30,7 @@ def metadata_from_context_data(data):
 
 
 def context_data_from_metadata(metadata):
-    """ Utility function transforming `metadata` into a context data dictionary.
+    """Utility function transforming `metadata` into a context data dictionary.
 
     Metadata may have been encoded at the client by `metadata_from_context_data`, or
     it may be "normal" GRPC metadata. In this case, duplicate values are allowed;
@@ -55,7 +55,7 @@ def context_data_from_metadata(metadata):
 
 
 class GrpcContext:
-    """ Context object passed to GRPC methods.
+    """Context object passed to GRPC methods.
 
     Gives access to request metadata and allows response metadata to be set.
     """

--- a/nameko_grpc/entrypoint.py
+++ b/nameko_grpc/entrypoint.py
@@ -131,7 +131,7 @@ class Grpc(Entrypoint):
 
     @classmethod
     def decorator(cls, stub, *args, **kwargs):
-        """ Override Entrypoint.decorator to ensure `stub` is passed to instance.
+        """Override Entrypoint.decorator to ensure `stub` is passed to instance.
 
         Would be nicer if Nameko had a better mechanism for this.
         """

--- a/nameko_grpc/entrypoint.py
+++ b/nameko_grpc/entrypoint.py
@@ -165,7 +165,14 @@ class Grpc(Entrypoint):
         request = request_stream.consume(self.input_type)
 
         if self.cardinality in (Cardinality.UNARY_STREAM, Cardinality.UNARY_UNARY):
-            request = next(request)
+            try:
+                request = next(request)
+            except Exception:
+                exc_info = sys.exc_info()
+                message = "Error parsing request: {}".format(exc_info[1])
+                error = GrpcError.from_exception(exc_info, message=message)
+                response_stream.close(error)
+                return
 
         context = GrpcContext(request_stream, response_stream)
 
@@ -185,7 +192,7 @@ class Grpc(Entrypoint):
             )
         except ContainerBeingKilled:
             raise GrpcError(
-                status=StatusCode.UNAVAILABLE, message="Server shutting down"
+                code=StatusCode.UNAVAILABLE, message="Server shutting down"
             )
 
     def handle_result(self, response_stream, worker_ctx, result, exc_info):

--- a/nameko_grpc/entrypoint.py
+++ b/nameko_grpc/entrypoint.py
@@ -169,8 +169,12 @@ class Grpc(Entrypoint):
                 request = next(request)
             except Exception:
                 exc_info = sys.exc_info()
-                message = "Error parsing request: {}".format(exc_info[1])
-                error = GrpcError.from_exception(exc_info, message=message)
+                message = "Exception deserializing request!"
+                error = GrpcError.from_exception(
+                    exc_info,
+                    code=StatusCode.INTERNAL,
+                    message=message,
+                )
                 response_stream.close(error)
                 return
 
@@ -191,9 +195,7 @@ class Grpc(Entrypoint):
                 handle_result=handle_result,
             )
         except ContainerBeingKilled:
-            raise GrpcError(
-                code=StatusCode.UNAVAILABLE, message="Server shutting down"
-            )
+            raise GrpcError(code=StatusCode.UNAVAILABLE, message="Server shutting down")
 
     def handle_result(self, response_stream, worker_ctx, result, exc_info):
 

--- a/nameko_grpc/errors.py
+++ b/nameko_grpc/errors.py
@@ -22,8 +22,7 @@ class GrpcError(Exception):
         self.status = status
 
     def as_headers(self):
-        """ Dehydrate this instance to headers to be sent as trailing metadata.
-        """
+        """Dehydrate this instance to headers to be sent as trailing metadata."""
         headers = {
             # ("content-length", "0"),
             "grpc-status": str(STATUS_CODE_ENUM_TO_INT_MAP[self.code]),
@@ -35,8 +34,7 @@ class GrpcError(Exception):
 
     @classmethod
     def from_headers(cls, headers):
-        """ Rehydrate a new instance from headers received as trailing metadata.
-        """
+        """Rehydrate a new instance from headers received as trailing metadata."""
         code = int(headers.get("grpc-status"))
         message = headers.get("grpc-message")
         status = headers.get(GRPC_DETAILS_METADATA_KEY)
@@ -57,7 +55,7 @@ class GrpcError(Exception):
 
     @staticmethod
     def from_exception(exc_info, code=None, message=None):
-        """ Utility method to create a new GrpcError instance representing an
+        """Utility method to create a new GrpcError instance representing an
         underlying exception. Useful in try/except clauses.
 
         By default, a `google.rpc.Status` message will be generated capturing the
@@ -86,7 +84,7 @@ def make_status(code, message, details=None):
 
 
 def register_exception_handler(exc_type, custom_error_from_exception):
-    """ Register a custom implementation to generate a GrpcError from an underlying
+    """Register a custom implementation to generate a GrpcError from an underlying
     exception, by exception type.
 
     Must be a callable with a signature matching `default_error_from_exception`.
@@ -95,13 +93,12 @@ def register_exception_handler(exc_type, custom_error_from_exception):
 
 
 def unregister_expection_handler(exc_type):
-    """ Unregister a custom implementation.
-    """
+    """Unregister a custom implementation."""
     registry.pop(exc_type, None)
 
 
 def default_error_from_exception(exc_info, code=None, message=None):
-    """ Create a new GrpcError instance representing an underlying exception.
+    """Create a new GrpcError instance representing an underlying exception.
 
     If the `GRPC_DEBUG` key is set in the Nameko config, the `status` message will
     capture the underyling traceback in a `google.rpc.error_details.DebugInfo` message.
@@ -117,7 +114,8 @@ def default_error_from_exception(exc_info, code=None, message=None):
         debug_info = Any()
         debug_info.Pack(
             DebugInfo(
-                stack_entries=traceback.format_exception(*exc_info), detail=str(exc),
+                stack_entries=traceback.format_exception(*exc_info),
+                detail=str(exc),
             )
         )
         status.details.append(debug_info)

--- a/nameko_grpc/headers.py
+++ b/nameko_grpc/headers.py
@@ -100,7 +100,7 @@ class HeaderManager:
         return list(map(encode_header, headers))
 
     def get(self, name, default=None):
-        """ Get a header by `name`.
+        """Get a header by `name`.
 
         Joins duplicate headers into a comma-separated string of values.
         """
@@ -113,7 +113,7 @@ class HeaderManager:
         return comma_join(matches)
 
     def set(self, *headers, from_wire=False):
-        """ Set headers.
+        """Set headers.
 
         Overwrites any existing header with the same name. Optionally decodes
         the headers first.
@@ -130,7 +130,7 @@ class HeaderManager:
         self.data.extend(headers)
 
     def append(self, *headers, from_wire=False):
-        """ Add new headers.
+        """Add new headers.
 
         Preserves and appends to any existing header with the same name. Optionally
         decodes the headers first.
@@ -145,12 +145,10 @@ class HeaderManager:
 
     @property
     def for_wire(self):
-        """ A sorted list of encoded headers for transmitting over the wire.
-        """
+        """A sorted list of encoded headers for transmitting over the wire."""
         return self.encode(sort_headers_for_wire(self.data))
 
     @property
     def for_application(self):
-        """ A filtered list of headers for use by the application.
-        """
+        """A filtered list of headers for use by the application."""
         return filter_headers_for_application(self.data)

--- a/nameko_grpc/ssl.py
+++ b/nameko_grpc/ssl.py
@@ -12,22 +12,22 @@ DEFAULT_SSL_CONFIG = {
 
 class SslConfig:
     def __init__(self, config):
-        """ Valid values for `config` are:
+        """Valid values for `config` are:
 
-            - True
-            - False
-            - A dict with the following format, all keys optional:
+        - True
+        - False
+        - A dict with the following format, all keys optional:
 
-                {
-                    "verify_mode": <"none"|"optional"|"required">,
-                    "check_hostname": <True|False>,
-                    "verify_locations": {
-                        <args for SslContext.load_verify_locations>
-                    },
-                    "cert_chain": {
-                        <args for SslContext.load_cert_chain>
-                    }
+            {
+                "verify_mode": <"none"|"optional"|"required">,
+                "check_hostname": <True|False>,
+                "verify_locations": {
+                    <args for SslContext.load_verify_locations>
+                },
+                "cert_chain": {
+                    <args for SslContext.load_cert_chain>
                 }
+            }
         """
         # TODO add schema for this config dict
         if config is True:
@@ -66,8 +66,7 @@ class SslConfig:
         return self.config.get("cert_chain", None)
 
     def server_context(self):
-        """ Returns a configured context for use in a server.
-        """
+        """Returns a configured context for use in a server."""
         context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         if self.cert_chain:
             context.load_cert_chain(**self.cert_chain)
@@ -75,8 +74,7 @@ class SslConfig:
         return context
 
     def client_context(self):
-        """ Returns a configured context for use in a client.
-        """
+        """Returns a configured context for use in a client."""
         context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         context.check_hostname = self.check_hostname
         context.verify_mode = self.verify_mode

--- a/nameko_grpc/streams.py
+++ b/nameko_grpc/streams.py
@@ -197,13 +197,16 @@ class SendStream(StreamBase):
 
             # add the bytes from the message to the buffer
             if message and message != STREAM_END:
-                body = message.SerializeToString()
+                body = self.serialize_message(message)
                 compressed, body = compress(body, self.encoding)
 
                 data = (
                     struct.pack("?", compressed) + struct.pack(">I", len(body)) + body
                 )
                 self.buffer.write(data)
+
+    def serialize_message(self, message):
+        return message.SerializeToString()
 
     def read(self, max_bytes, chunk_size):
         """ Read up to `max_bytes` from the stream, yielding up to `chunk_size`

--- a/nameko_grpc/streams.py
+++ b/nameko_grpc/streams.py
@@ -55,13 +55,13 @@ class StreamBase:
 
     @property
     def exhausted(self):
-        """ A stream is exhausted if it is closed and there are no more messages to be
+        """A stream is exhausted if it is closed and there are no more messages to be
         consumed or bytes to be read.
         """
         return self.closed and self.queue.empty() and self.buffer.empty()
 
     def close(self, error=None):
-        """ Close this stream, preventing further messages or data to be added.
+        """Close this stream, preventing further messages or data to be added.
 
         If closed with an error, the error will be raised when reading
         or consuming from this stream.
@@ -86,13 +86,12 @@ class StreamBase:
 
 
 class ReceiveStream(StreamBase):
-    """ An HTTP2 stream that receives data as bytes to be iterated over as GRPC
+    """An HTTP2 stream that receives data as bytes to be iterated over as GRPC
     messages.
     """
 
     def write(self, data):
-        """ Write data to this stream, separating it into message-sized chunks.
-        """
+        """Write data to this stream, separating it into message-sized chunks."""
         if self.closed:
             return
 
@@ -113,7 +112,7 @@ class ReceiveStream(StreamBase):
             self.queue.put((compressed_flag, message_data))
 
     def consume(self, message_type):
-        """ Consume the data in this stream by yielding `message_type` messages,
+        """Consume the data in this stream by yielding `message_type` messages,
         or raising if the stream was closed with an error.
         """
         while True:
@@ -134,7 +133,7 @@ class ReceiveStream(StreamBase):
 
 
 class SendStream(StreamBase):
-    """ An HTTP2 stream that receives data as GRPC messages to be read as chunks of
+    """An HTTP2 stream that receives data as GRPC messages to be read as chunks of
     bytes.
     """
 
@@ -147,8 +146,7 @@ class SendStream(StreamBase):
         return self.headers.get("grpc-encoding")
 
     def populate(self, iterable):
-        """ Populate this stream with an iterable of messages.
-        """
+        """Populate this stream with an iterable of messages."""
         for item in iterable:
             if self.closed:
                 return
@@ -156,7 +154,7 @@ class SendStream(StreamBase):
         self.close()
 
     def headers_to_send(self, defer_until_data=True):
-        """ Return any headers to be sent with this stream.
+        """Return any headers to be sent with this stream.
 
         Headers may only be transmitted before any data is sent.
         This state is maintained by only returning headers from this method once.
@@ -175,16 +173,14 @@ class SendStream(StreamBase):
         return self.headers.for_wire
 
     def trailers_to_send(self):
-        """ Return any trailers to be sent after this stream.
-        """
+        """Return any trailers to be sent after this stream."""
         if len(self.trailers) == 0:
             return False
 
         return self.trailers.for_wire
 
     def flush_queue_to_buffer(self):
-        """ Write the bytes from any messages in the queue to the buffer.
-        """
+        """Write the bytes from any messages in the queue to the buffer."""
         while True:
             try:
                 message = self.queue.get_nowait()
@@ -209,7 +205,7 @@ class SendStream(StreamBase):
         return message.SerializeToString()
 
     def read(self, max_bytes, chunk_size):
-        """ Read up to `max_bytes` from the stream, yielding up to `chunk_size`
+        """Read up to `max_bytes` from the stream, yielding up to `chunk_size`
         bytes at a time.
         """
         sent = 0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "dev": [
             "coverage",
             "pytest",
-            "pytest-eventlet",
             "pytest-timeout",
             "grpcio-tools",
             "grpcio-status",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "dev": [
             "coverage",
             "pytest",
+            "pytest-eventlet",
             "pytest-timeout",
             "grpcio-tools",
             "grpcio-status",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "grpcio",
         "protobuf",
         "googleapis-common-protos",
+        "importlib-metadata<5.0.0",
     ],
     extras_require={
         "dev": [

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -22,7 +22,7 @@ def status_from_metadata(metadata):
 
 
 def extract_metadata(context):
-    """ Extracts invocation metadata from `context` and returns it as JSON.
+    """Extracts invocation metadata from `context` and returns it as JSON.
 
     Binary headers are included as base64 encoded strings.
     Duplicate header values are joined as comma separated, preserving order.
@@ -39,8 +39,7 @@ def extract_metadata(context):
 
 
 def maybe_echo_metadata(context):
-    """ Copy metadata from request to response.
-    """
+    """Copy metadata from request to response."""
     initial_metadata = []
     trailing_metadata = []
 
@@ -62,8 +61,7 @@ def maybe_sleep(request):
 
 
 class RemoteClientTransport:
-    """ Serialializes/deserializes objects through ZMQ sockets using `pickle`.
-    """
+    """Serialializes/deserializes objects through ZMQ sockets using `pickle`."""
 
     ENDSTREAM = "endstream"
 
@@ -72,7 +70,7 @@ class RemoteClientTransport:
 
     @classmethod
     def bind(cls, context, socket_type, target):
-        """ Create a new transport over a ZMQ socket of type `socket_type`, bound
+        """Create a new transport over a ZMQ socket of type `socket_type`, bound
         to the `target` address.
         """
         socket = context.socket(socket_type)
@@ -87,7 +85,7 @@ class RemoteClientTransport:
 
     @classmethod
     def connect(cls, context, socket_type, target):
-        """ Create a new transport over a ZMQ socket of type `socket_type`, connected
+        """Create a new transport over a ZMQ socket of type `socket_type`, connected
         to the `target` address.
         """
         socket = context.socket(socket_type)
@@ -138,7 +136,7 @@ class RemoteClientTransport:
 
 
 class Command:
-    """ Encapsulates a command to run on a remote GRPC client.
+    """Encapsulates a command to run on a remote GRPC client.
 
     A command can be issued to a remote client, or responded to by that remote client.
 
@@ -194,7 +192,7 @@ class Command:
         self.__dict__.update(newstate)
 
     def issue(self):
-        """ Issue this command to a remote client.
+        """Issue this command to a remote client.
 
         Sends itelf over the given `transport`.
         """
@@ -211,8 +209,7 @@ class Command:
 
     @staticmethod
     def retrieve_commands(transport):
-        """ Retrieve a series of commands over the given `transport`
-        """
+        """Retrieve a series of commands over the given `transport`"""
         # this is actually just receive_stream...
         while True:
             command = transport.receive()
@@ -225,16 +222,14 @@ class Command:
         transport.close()
 
     def bind_transport(self, socket_type):
-        """ Bind a new transport using the given `socket_type`.
-        """
+        """Bind a new transport using the given `socket_type`."""
         transport, port = RemoteClientTransport.bind_to_free_port(
             self.transport.context, socket_type, "tcp://127.0.0.1"
         )
         return transport, port
 
     def connect_transport(self, socket_type, port):
-        """ Connect a new transport to `port` using the given `socket_type`.
-        """
+        """Connect a new transport to `port` using the given `socket_type`."""
         transport = RemoteClientTransport.connect(
             self.transport.context, socket_type, "tcp://127.0.0.1:{}".format(port)
         )
@@ -242,7 +237,7 @@ class Command:
 
     @property
     def request_transport(self):
-        """ Bind or connect the request transport.
+        """Bind or connect the request transport.
 
         Depending on the mode of this command, either binds a new transport to a free
         port, or connects to the established port.
@@ -257,7 +252,7 @@ class Command:
 
     @property
     def response_transport(self):
-        """ Bind or connect the response transport.
+        """Bind or connect the response transport.
 
         Depending on the mode of this command, either binds a new transport to a free
         port, or connects to the established port.
@@ -272,7 +267,7 @@ class Command:
 
     @property
     def metadata_transport(self):
-        """ Bind or connect the metadata transport.
+        """Bind or connect the metadata transport.
 
         Depending on the mode of this command, either binds a new transport to a free
         port, or connects to the established port.
@@ -286,7 +281,7 @@ class Command:
         return self._metadata_transport
 
     def send_request(self, request):
-        """ Send the request for this command to the remote client.
+        """Send the request for this command to the remote client.
 
         Only available in ISSUE mode.
         """
@@ -301,7 +296,7 @@ class Command:
             self.request_transport.send(request, close=True)
 
     def get_request(self):
-        """ Get the request for this command from the caller.
+        """Get the request for this command from the caller.
 
         Only available in RESPOND mode.
         """
@@ -313,8 +308,7 @@ class Command:
         return self.request_transport.receive(close=True)
 
     def send_response(self, response):
-        """ Send the response for this command
-        """
+        """Send the response for this command"""
         if self.mode is not Command.Modes.RESPOND:
             raise ValueError("Command must be in RESPOND mode to send a response")
 
@@ -326,8 +320,7 @@ class Command:
             self.response_transport.send(response, close=True)
 
     def get_response(self):
-        """ Get the response for this command from the remote client
-        """
+        """Get the response for this command from the remote client"""
         if self.mode is not Command.Modes.ISSUE:
             raise ValueError("Command must be in ISSUE mode to get a response")
 
@@ -336,16 +329,14 @@ class Command:
         return self.response_transport.receive(close=True)
 
     def send_metadata(self, metadata):
-        """ Send the response metadata for this command
-        """
+        """Send the response metadata for this command"""
         if self.mode is not Command.Modes.RESPOND:
             raise ValueError("Command must be in RESPOND mode to send metadata")
 
         self.metadata_transport.send(metadata, close=True)
 
     def get_metadata(self):
-        """ Get the response metadata for this command from the remote client
-        """
+        """Get the response metadata for this command from the remote client"""
         if self.mode is not Command.Modes.ISSUE:
             raise ValueError("Command must be in ISSUE mode to get a metadata")
 
@@ -409,7 +400,7 @@ class Stash:
 
 @wrapt.decorator
 def instrumented(wrapped, instance, args, kwargs):
-    """ Decorator for instrumenting GRPC implementation methods.
+    """Decorator for instrumenting GRPC implementation methods.
 
     Stores requests and responses to file for later inspection.
     """

--- a/test/spec/example_grpc.py
+++ b/test/spec/example_grpc.py
@@ -62,7 +62,10 @@ class example(example_pb2_grpc.exampleServicer):
     def unary_error_via_context(self, request, context):
         # using rich status to test compatibility with
         # https://grpc.github.io/grpc/python/grpc_status.html
-        status = make_status(code=StatusCode.UNAUTHENTICATED, message="Not allowed!",)
+        status = make_status(
+            code=StatusCode.UNAUTHENTICATED,
+            message="Not allowed!",
+        )
         context.abort_with_status(rpc_status.to_status(status))
 
     @instrumented

--- a/test/spec/example_nameko.py
+++ b/test/spec/example_nameko.py
@@ -153,6 +153,8 @@ class example:
                 message = "Out of tokens!"
 
                 raise GrpcError(
-                    code=code, message=message, status=make_status(code, message),
+                    code=code,
+                    message=message,
+                    status=make_status(code, message),
                 )
             yield ExampleReply(message=message, seqno=i + 1, metadata=metadata)

--- a/test/test_channel.py
+++ b/test/test_channel.py
@@ -17,7 +17,7 @@ class TestDisposeServerConnectionOnExit:
         return request.param[7:]
 
     def test_dispose(self, server, load_stubs, spec_dir, grpc_port, protobufs):
-        """ Regression test for server connection part of
+        """Regression test for server connection part of
         https://github.com/nameko/nameko-grpc/issues/40
         """
         stubs = load_stubs("example")
@@ -57,7 +57,7 @@ class TestDisposeClientConnectionOnExit:
         return request.param[7:]
 
     def test_dispose(self, server, load_stubs, spec_dir, grpc_port, protobufs):
-        """ Regression test for client connection part of
+        """Regression test for client connection part of
         https://github.com/nameko/nameko-grpc/issues/40
         """
         stubs = load_stubs("example")

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -17,7 +17,7 @@ from nameko_grpc.errors import GrpcError
 
 @pytest.mark.equivalence
 class TestCompression:
-    """ Some of these tests are incomplete because the standard Python GRPC client
+    """Some of these tests are incomplete because the standard Python GRPC client
     and/or server don't conform to the spec.
 
     See https://stackoverflow.com/questions/53233339/what-is-the-state-of-compression-
@@ -165,7 +165,7 @@ class TestCompression:
     def test_request_unsupported_algorithm_at_server(
         self, start_client, start_server, protobufs, client_type, server_type
     ):
-        """ It's not possible to run this test with the GRPC server.
+        """It's not possible to run this test with the GRPC server.
 
         The server can be configured to disable certain compression algorithms with
         the grpc.compression_enabled_algorithms_bitset server option. Unfortunately,
@@ -223,7 +223,7 @@ class TestCompression:
         pass
 
     def test_respond_with_different_algorithm(self):
-        """ The GRPC server doesn't seem to support this behaviour. It's either
+        """The GRPC server doesn't seem to support this behaviour. It's either
         explicitly not supported, or there is a bug that results in an error if the
         server also has a default compression algorithm set.
 
@@ -234,7 +234,7 @@ class TestCompression:
         pytest.skip("See docstring for details")
 
     def test_disable_compression_for_message(self):
-        """ The non-beta GRPC client doesn't support any way to disable compression
+        """The non-beta GRPC client doesn't support any way to disable compression
         for a call. Additionally, it's not clear how the client should request that
         an the next _message_ should be sent uncompressed as described in the spec.
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -13,8 +13,7 @@ class TestCloseSocketOnClientExit:
         return request.param[7:]
 
     def test_close_socket(self, server, load_stubs, spec_dir, grpc_port, protobufs):
-        """ Regression test for https://github.com/nameko/nameko-grpc/issues/39
-        """
+        """Regression test for https://github.com/nameko/nameko-grpc/issues/39"""
         stubs = load_stubs("example")
 
         client = Client(

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -3,6 +3,7 @@ import json
 import re
 import string
 import time
+from unittest import mock
 
 import pytest
 from grpc import StatusCode
@@ -350,8 +351,6 @@ class TestErrorInvalidRequest:
         return request.param[7:]
 
     def test_invalid_request(self, client, protobufs):
-        from unittest import mock
-
         with mock.patch(
             "nameko_grpc.streams.SendStream.serialize_message",
             return_value=b"some rubbish",

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -351,8 +351,11 @@ class TestErrorInvalidRequest:
 
     def test_invalid_request(self, client, protobufs):
         from unittest import mock
-        with mock.patch("nameko_grpc.streams.SendStream.serialize_message",
-                        return_value=b'some rubbish'):
+
+        with mock.patch(
+            "nameko_grpc.streams.SendStream.serialize_message",
+            return_value=b"some rubbish",
+        ):
             with pytest.raises(GrpcError) as error:
                 client.unary_unary(protobufs.ExampleRequest(value="hello"))
         assert error.value.code == StatusCode.INTERNAL

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -342,3 +342,18 @@ class TestCustomErrorFromException:
         assert status.code == StatusCode.PERMISSION_DENIED.value[0]
         assert status.message == "Not allowed!"
         assert not status.details
+
+
+class TestErrorInvalidRequest:
+    @pytest.fixture(params=["client=nameko"])
+    def client_type(self, request):
+        return request.param[7:]
+
+    def test_invalid_request(self, client, protobufs):
+        from unittest import mock
+        with mock.patch("nameko_grpc.streams.SendStream.serialize_message",
+                        return_value=b'some rubbish'):
+            with pytest.raises(GrpcError) as error:
+                client.unary_unary(protobufs.ExampleRequest(value="hello"))
+        assert error.value.code == StatusCode.INTERNAL
+        assert error.value.message == "Exception deserializing request!"

--- a/test/test_headers.py
+++ b/test/test_headers.py
@@ -38,7 +38,10 @@ class TestDecodeHeader:
         assert padded_value.endswith(b"=")
 
         trimmed_value = padded_value[:-2]
-        assert decode_header((b"foo-bin", trimmed_value)) == ("foo-bin", b"1234",)
+        assert decode_header((b"foo-bin", trimmed_value)) == (
+            "foo-bin",
+            b"1234",
+        )
 
     def test_string_value(self):
         assert decode_header((b"foo", b"123")) == ("foo", "123")

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -303,7 +303,7 @@ def generate_messages():
         compress.side_effect = lambda body, _: (False, body)
 
         def generate(count, length):
-            """ Generate a series of mock messages.
+            """Generate a series of mock messages.
 
             If `count` is 2 and `length` is 4, when passed to `stream.populate`,
             two messages with the following payload will be added to the stream's


### PR DESCRIPTION
Any error during the parsing of request message for a unary request would be fatal, so we're catching it and returning a `GrpcError` in line with the `grpc` library.

I've had to pin importlib-metadata due to a breaking release for python < 3.8. It looks like the issue will be fixed in the next version of `kombu` https://github.com/celery/kombu/pull/1601

Annoyingly black was failing in CI due to a compatibility issue, so I've upgraded it. Sorry for the messy diff!