### PR TITLE
Catch StopIteration and raise grpc error

### DIFF
--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -42,7 +42,7 @@ class Future:
             except StopIteration:
                 raise GrpcError(
                     code=StatusCode.UNAVAILABLE,
-                    message="Stream was closed mid connection"
+                    message="Stream was closed mid connection",
                 )
         return response
 

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -37,7 +37,13 @@ class Future:
     def result(self):
         response = self.response_stream.consume(self.output_type)
         if self.cardinality in (Cardinality.STREAM_UNARY, Cardinality.UNARY_UNARY):
-            response = next(response)
+            try:
+                response = next(response)
+            except StopIteration:
+                raise GrpcError(
+                    code=StatusCode.UNAVAILABLE,
+                    message="Stream was closed mid connection"
+                )
         return response
 
 

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -42,7 +42,7 @@ class Future:
             except StopIteration:
                 raise GrpcError(
                     code=StatusCode.UNAVAILABLE,
-                    message="Stream was closed mid connection",
+                    message="Stream was closed mid-request",
                 )
         return response
 

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -373,6 +373,6 @@ class TestErrorStreamClosed:
             return_value=[ConnectionTerminated()],
         ):
             with pytest.raises(GrpcError) as error:
-                resp = client.unary_unary(protobufs.ExampleRequest(value="hello"))
+                client.unary_unary(protobufs.ExampleRequest(value="hello"))
         assert error.value.code == StatusCode.UNAVAILABLE
         assert error.value.message == "Stream was closed mid connection"

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -375,4 +375,4 @@ class TestErrorStreamClosed:
             with pytest.raises(GrpcError) as error:
                 client.unary_unary(protobufs.ExampleRequest(value="hello"))
         assert error.value.code == StatusCode.UNAVAILABLE
-        assert error.value.message == "Stream was closed mid connection"
+        assert error.value.message == "Stream was closed mid-request"


### PR DESCRIPTION
# Summary
It's possible for a connection to terminate before a response has been returned. In this case, we end the stream iterator

```
    def consume(self, message_type):
        """Consume the data in this stream by yielding `message_type` messages,
        or raising if the stream was closed with an error.
        """
        while True:
            item = self.queue.get()
            if isinstance(item, GrpcError):
                raise item
            elif item is STREAM_END:
                break
```

If a stream is closed before a response is returned then the stream 'breaks', raising a StopIteration exception which we need to handle. We can't just check if it's closed as we want it to raise any errors. 

### Notes:
- Not sure if there's a better error message. Likely there is.