### PR TITLE
Prevent reusing stream ids

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
@@ -33,7 +33,7 @@ jobs:
          TOXENV: static
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:
@@ -44,10 +44,10 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -74,10 +74,10 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__
 *_pb2.py
 *_pb2_grpc.py
 .coverage
+.DS_Store
+.idea/
+build/
+dist/

--- a/nameko_grpc/connection.py
+++ b/nameko_grpc/connection.py
@@ -214,12 +214,15 @@ class ConnectionManager:
     def stream_reset(self, event):
         """Called when an incoming stream is reset.
 
-        Close any `ReceiveStream` that was opened for this stream.
+        Close any Streams that we have opened for this stream_id
         """
         log.debug("stream reset, stream %s", event.stream_id)
         receive_stream = self.receive_streams.pop(event.stream_id, None)
         if receive_stream:
             receive_stream.close()
+        send_stream = self.send_streams.pop(event.stream_id, None)
+        if send_stream:
+            send_stream.close()
 
     def settings_changed(self, event):
         log.debug("settings changed")

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = static, {py3.6,py3.7,py3.8,py3.9}-test
 skipsdist = True
 
 [testenv]
-whitelist_externals = make
+allowlist_externals = make
 
 commands =
     static: pip install pre-commit


### PR DESCRIPTION
When we receive a StreamReset frame (for eg; when a client terminates a stream on timeout), we currently cleanup the receive stream but leave the send stream.
Stream objects in nameko-grpc are just wrappers for a single underlying http/2 stream
```
        request_stream = SendStream(stream_id)
        response_stream = ReceiveStream(stream_id)
        self.receive_streams[stream_id] = response_stream
        self.send_streams[stream_id] = request_stream
```
So when we don't cleanup both of these objects on stream close we can attempt to send data again on the SendStream object, which will either attempt to send data on a closed stream `StreamClosedError` (if h2 hasn't discared its reference to the underyling stream yet, or if it has, h2 will create a new stream object with the previous stream_id, resulting in the `StreamIDTooLowError` error when we attempt to send data.

This PR fixes this by ensuring the SendStream object is removed from our references when we receive a StreamResetframe.