### PR TITLE
Cooperate with eventlet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
@@ -33,7 +33,7 @@ jobs:
          TOXENV: static
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:
@@ -44,10 +44,10 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -74,10 +74,10 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/nameko_grpc/streams.py
+++ b/nameko_grpc/streams.py
@@ -2,6 +2,8 @@
 import struct
 from queue import Empty, Queue
 
+from eventlet import greenthread
+
 from nameko_grpc.compression import compress, decompress
 from nameko_grpc.errors import GrpcError
 from nameko_grpc.headers import HeaderManager
@@ -200,6 +202,14 @@ class SendStream(StreamBase):
                     struct.pack("?", compressed) + struct.pack(">I", len(body)) + body
                 )
                 self.buffer.write(data)
+
+            # This while loop can lockup the main thread for a long time if we have a
+            # large queue of large messages to process. We need to yield to cooperate
+            # with eventlet greenthreads and this is the canonical way of doing so.
+            # Calling :func:`~greenthread.sleep` with *seconds* of 0 is the
+            #     canonical way of expressing a cooperative yield
+            # TODO: Consider alternative solutions, ie breaking the flush into chunks
+            greenthread.sleep(0)
 
     def serialize_message(self, message):
         return message.SerializeToString()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = static, {py3.6,py3.7,py3.8,py3.9}-test
 skipsdist = True
 
 [testenv]
-whitelist_externals = make
+allowlist_externals = make
 
 commands =
     static: pip install pre-commit


### PR DESCRIPTION
# Summary
This function 'flush_queue_to_buffer' has no socket io and thus never yields back to the greenlet event loop. When a large response is combined with a large  number of responses (ie, streaming a large response) it can take a long time to finish the call as it loops through serializing every message, resulting in *everything* blocking until the call finishes.
