### PR TITLE
Add "lazy" connection option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.3.0
     hooks:
     -   id: trailing-whitespace
@@ -7,11 +7,13 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-encoding-pragma
     -   id: flake8
--   repo: https://github.com/mattbennett/mirrors-isort.git
-    rev: master
+-   repo: https://github.com/PyCQA/isort
+    rev: 4.3.21
     hooks:
     - id: isort
 -   repo: https://github.com/ambv/black
     rev: 19.10b0
     hooks:
     - id: black
+      # TODO remove this when black is updated
+      additional_dependencies: [ 'click==8.0.4' ]

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -152,7 +152,9 @@ class ClientBase:
             return channel
 
     def stop(self):
-        self._channel.stop()
+        if self._channel is not None:
+            self._channel.stop()
+            self._channel = None
 
     @property
     def channel(self):

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -143,13 +143,14 @@ class ClientBase:
 
     def start(self):
         if not self.lazy:
-            self._channel = self._get_channel()
+            self._start_channel()
 
-    def _get_channel(self):
+    def _start_channel(self):
         with self._channel_creation_lock:
-            channel = ClientChannel(self.target, self.ssl, self.spawn_thread)
-            channel.start()
-            return channel
+            if self._channel is None:
+                channel = ClientChannel(self.target, self.ssl, self.spawn_thread)
+                channel.start()
+                self._channel = channel
 
     def stop(self):
         if self._channel is not None:
@@ -159,7 +160,7 @@ class ClientBase:
     @property
     def channel(self):
         if self._channel is None:
-            self._channel = self._get_channel()
+            self._start_channel()
         return self._channel
 
     def timeout(self, send_stream, response_stream, deadline):

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -121,14 +121,14 @@ class ClientBase:
         compression_algorithm="none",
         compression_level="high",
         ssl=False,
-        lazy=False,
+        lazy_startup=False,
     ):
         self.target = target
         self.stub = stub
         self.compression_algorithm = compression_algorithm
         self.compression_level = compression_level  # NOTE not used
         self.ssl = SslConfig(ssl)
-        self.lazy = lazy
+        self.lazy_startup = lazy_startup
         self._channel_creation_lock = threading.Lock()
         self._channel = None
 
@@ -142,7 +142,7 @@ class ClientBase:
         return "identity"
 
     def start(self):
-        if not self.lazy:
+        if not self.lazy_startup:
             self._start_channel()
 
     def _start_channel(self):

--- a/nameko_grpc/client.py
+++ b/nameko_grpc/client.py
@@ -129,6 +129,7 @@ class ClientBase:
         self.compression_level = compression_level  # NOTE not used
         self.ssl = SslConfig(ssl)
         self.lazy = lazy
+        self._channel_creation_lock = threading.Lock()
         self._channel = None
 
     def spawn_thread(self, target, args=(), kwargs=None, name=None):
@@ -145,9 +146,10 @@ class ClientBase:
             self._channel = self._get_channel()
 
     def _get_channel(self):
-        channel = ClientChannel(self.target, self.ssl, self.spawn_thread)
-        channel.start()
-        return channel
+        with self._channel_creation_lock:
+            channel = ClientChannel(self.target, self.ssl, self.spawn_thread)
+            channel.start()
+            return channel
 
     def stop(self):
         self._channel.stop()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -352,6 +352,8 @@ def start_nameko_client(request, load_stubs, spec_dir, grpc_port):
         proto_name=None,
         compression_algorithm="none",
         compression_level="high",
+        lazy=False,
+        service_url="//localhost:{}".format(grpc_port),
     ):
         if proto_name is None:
             proto_name = service_name
@@ -359,11 +361,12 @@ def start_nameko_client(request, load_stubs, spec_dir, grpc_port):
         stubs = load_stubs(proto_name)
         stub_cls = getattr(stubs, "{}Stub".format(service_name))
         client = Client(
-            "//localhost:{}".format(grpc_port),
+            service_url,
             stub_cls,
             compression_algorithm,
             compression_level,
             ssl_options,
+            lazy=lazy,
         )
         clients.append(client)
         return client.start()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -352,7 +352,7 @@ def start_nameko_client(request, load_stubs, spec_dir, grpc_port):
         proto_name=None,
         compression_algorithm="none",
         compression_level="high",
-        lazy=False,
+        lazy_startup=False,
         service_url="//localhost:{}".format(grpc_port),
     ):
         if proto_name is None:
@@ -366,7 +366,7 @@ def start_nameko_client(request, load_stubs, spec_dir, grpc_port):
             compression_algorithm,
             compression_level,
             ssl_options,
-            lazy=lazy,
+            lazy_startup=lazy_startup,
         )
         clients.append(client)
         return client.start()

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -113,7 +113,7 @@ class TestFuture:
 
 class TestLazy:
     def test_lazy_client(self, start_nameko_client, server, protobufs):
-        client = start_nameko_client("example", lazy=True)
+        client = start_nameko_client("example", lazy_startup=True)
         response = client.unary_unary(protobufs.ExampleRequest(value="A"))
         assert response.message == "A"
 
@@ -121,7 +121,7 @@ class TestLazy:
     def test_lazy_client_does_not_connect_on_start(
         self, start_nameko_client, protobufs, start_grpc_server
     ):
-        client = start_nameko_client("example", lazy=True)
+        client = start_nameko_client("example", lazy_startup=True)
 
         with pytest.raises(ConnectionRefusedError):
             client.unary_unary(protobufs.ExampleRequest(value="A"))
@@ -135,4 +135,4 @@ class TestLazy:
     # Note lack of server fixture
     def test_nonlazy_client_connects_on_start(self, start_nameko_client, protobufs):
         with pytest.raises(ConnectionRefusedError):
-            start_nameko_client("example", lazy=False)
+            start_nameko_client("example", lazy_startup=False)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -109,3 +109,30 @@ class TestFuture:
             ("A", 1),
             ("B", 2),
         ]
+
+
+class TestLazy:
+    def test_lazy_client(self, start_nameko_client, server, protobufs):
+        client = start_nameko_client("example", lazy=True)
+        response = client.unary_unary(protobufs.ExampleRequest(value="A"))
+        assert response.message == "A"
+
+    # Note lack of server fixture
+    def test_lazy_client_does_not_connect_on_start(
+        self, start_nameko_client, protobufs, start_grpc_server
+    ):
+        client = start_nameko_client("example", lazy=True)
+
+        with pytest.raises(ConnectionRefusedError):
+            client.unary_unary(protobufs.ExampleRequest(value="A"))
+
+        start_grpc_server("example")
+
+        # After starting the server, should now work
+        response = client.unary_unary(protobufs.ExampleRequest(value="A"))
+        assert response.message == "A"
+
+    # Note lack of server fixture
+    def test_nonlazy_client_connects_on_start(self, start_nameko_client, protobufs):
+        with pytest.raises(ConnectionRefusedError):
+            start_nameko_client("example", lazy=False)


### PR DESCRIPTION
Add a "lazy" option to the client/dependency provider, defaulting to `False`. This option means we only try to connect when a call is made rather than on startup.

This avoids cases where a dependent service won't start unless its dependency service is already running. Otherwise cascading failures might be a problem.