### PR TITLE
Add target context to connection error

### DIFF
--- a/nameko_grpc/channel.py
+++ b/nameko_grpc/channel.py
@@ -77,7 +77,10 @@ class ClientConnectionPool:
     def start(self):
         self.run = True
         for target in self.targets:
-            self.connect(urlparse(target))
+            try:
+                self.connect(urlparse(target))
+            except OSError as e:
+                raise type(e)(f"Failed to connect to {target}") from e
 
     def stop(self):
         self.run = False

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, "README.md"), "r", "utf-8") as handle:
 
 setup(
     name="nameko-grpc",
-    version="1.4.0rc2",
+    version="1.4.0rc3",
     description="Nameko gRPC extensions",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When a service is failing due to a misconfigured `GrpcProxy`, it's hard to tell which one is failing. This PR re-raises the same exception type with the `target` as context, and chained to the original exception.